### PR TITLE
Update merge bot workflow for GitHub Actions integration

### DIFF
--- a/.github/workflows/merge-bot-pull-request.yml
+++ b/.github/workflows/merge-bot-pull-request.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      # Merge all GitHub Actions updates (major versions are common e.g. v2->v3),
-      # but skip major version NuGet updates as they may contain breaking changes.
+      # Skip major version NuGet updates as they may contain breaking changes.
+      # All other ecosystems (e.g. github-actions) allow major updates (e.g. v2->v3).
       - name: Merge pull request step
-        if: steps.metadata.outputs.package-ecosystem == 'github_actions' || steps.metadata.outputs.update-type != 'version-update:semver-major'
+        if: steps.metadata.outputs.package-ecosystem != 'nuget' || steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/merge-bot-pull-request.yml
+++ b/.github/workflows/merge-bot-pull-request.yml
@@ -26,10 +26,13 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      # Skip major version NuGet updates as they may contain breaking changes.
-      # All other ecosystems (e.g. github-actions) allow major updates (e.g. v2->v3).
+      # Merge if either condition is true:
+      #   Non-NuGet ecosystems (e.g. github-actions) allow all updates including major (e.g. v2->v3)
+      #   NuGet allows only minor and patch updates, skipping major as they may contain breaking changes
       - name: Merge pull request step
-        if: (steps.metadata.outputs.package-ecosystem != 'nuget') || (steps.metadata.outputs.update-type != 'version-update:semver-major')
+        if: >-
+          (steps.metadata.outputs.package-ecosystem != 'nuget') ||
+          (steps.metadata.outputs.update-type != 'version-update:semver-major')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/merge-bot-pull-request.yml
+++ b/.github/workflows/merge-bot-pull-request.yml
@@ -26,8 +26,10 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      # Merge all GitHub Actions updates (major versions are common e.g. v2->v3),
+      # but skip major version NuGet updates as they may contain breaking changes.
       - name: Merge pull request step
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        if: steps.metadata.outputs.package-ecosystem == 'github_actions' || steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/merge-bot-pull-request.yml
+++ b/.github/workflows/merge-bot-pull-request.yml
@@ -29,7 +29,7 @@ jobs:
       # Skip major version NuGet updates as they may contain breaking changes.
       # All other ecosystems (e.g. github-actions) allow major updates (e.g. v2->v3).
       - name: Merge pull request step
-        if: steps.metadata.outputs.package-ecosystem != 'nuget' || steps.metadata.outputs.update-type != 'version-update:semver-major'
+        if: (steps.metadata.outputs.package-ecosystem != 'nuget') || (steps.metadata.outputs.update-type != 'version-update:semver-major')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
Enhance the merge conditions to include updates for GitHub Actions while excluding major version NuGet updates to prevent potential breaking changes.