### PR TITLE
Release: sync to ProjectTemplate standards (#130)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,108 @@
 # GitHub Copilot Instructions for LanguageTags
 
+The **canonical guide is [AGENTS.md](../AGENTS.md)** at the repo root — read it first. It covers branching, PR review etiquette, workflow YAML conventions, and the release pipeline.
+
+This file is intentionally focused: the GitHub Copilot Review Runbook (provider-specific mechanics behind the review-loop contract defined in AGENTS.md), followed by the LanguageTags-specific code conventions and public-API contract notes that VS Code's AI generators pick up directly from this path.
+
+For C# style rules, see [`CODESTYLE.md`](../CODESTYLE.md) at the repo root. Do not duplicate those rules here.
+
+## GitHub Copilot Review Runbook
+
+Use this section for provider-specific mechanics. The expected review loop *contract* (request review on every push, verify head-SHA coverage, triage findings, reply + resolve, escalate when stuck) is defined in [AGENTS.md → PR Review Etiquette](../AGENTS.md#pr-review-etiquette). This section only describes how to make GitHub Copilot reliably execute it.
+
+### Triggering and Polling
+
+Auto-review on push is configured (via the branch ruleset's `copilot_code_review` rule with `review_on_push: true`) but fires inconsistently in practice — treat it as best-effort, not guaranteed. Request review explicitly through the GitHub PR UI (request `Copilot` as a reviewer) after every push.
+
+**Do NOT post `@Copilot review` as a PR comment.** That comment triggers the Copilot *coding agent* (`copilot-swe-agent[bot]`), which makes code changes rather than posting a review.
+
+Known non-working request paths (don't rely on them):
+
+- `POST /requested_reviewers` with `reviewers=[Copilot]` can return 200 but no-op.
+- `copilot-pull-request-reviewer` as a requested reviewer slug returns 422.
+- GraphQL `requestReviews` rejects Copilot's bot node.
+
+### Verify Review Covered Current Head
+
+Before merging, confirm Copilot reviewed the current PR head SHA. Copilot may respond as either a formal review (carries an exact commit SHA) or an issue comment (no SHA — use the most recent Copilot comment for manual confirmation). Check both.
+
+```sh
+PR_HEAD=$(gh pr view <N> --json headRefOid --jq '.headRefOid')
+
+# 1. Formal review — exact SHA match.
+gh pr view <N> --json reviews --jq \
+  '.reviews[] | select(.author.login=="copilot-pull-request-reviewer") | .commit.oid' \
+  | grep -q "$PR_HEAD" && echo "covered via formal review"
+
+# 2. Issue comment — show the most recent Copilot comment for manual confirmation.
+gh api repos/ptr727/LanguageTags/issues/<N>/comments --jq \
+  '[.[] | select(.user.login=="copilot-pull-request-reviewer")] | last | {created_at, body: .body[:200]}'
+```
+
+Coverage is confirmed when (1) exits 0. For issue comments (path 2), body content is the only reliable signal — `created_at` is not: `git log -1 --format=%cI` is the **commit** timestamp, not the push timestamp, so amended or rebased commits can have an earlier timestamp and an older Copilot comment could satisfy a time check even though Copilot never saw the current head. Treat path (2) as confirmed only when the comment body explicitly refers to the current changes.
+
+### Bounded Retry Workflow
+
+If a review did not run on the current head, retry:
+
+1. Wait briefly and check head-SHA coverage (see above).
+1. Request review again via the GitHub PR UI.
+1. Retry up to two more times (three total).
+1. If still missing, mark review as blocked and escalate to the user/maintainer with what was attempted.
+
+### Reply and Thread Resolution Workflow
+
+List unresolved threads. Use `first: 100` with cursor-based pagination; if `hasNextPage` is true, re-run with `after: "<endCursor>"` to retrieve the next page:
+
+```sh
+gh api graphql -f query='
+{
+  repository(owner: "ptr727", name: "LanguageTags") {
+    pullRequest(number: <N>) {
+      reviewThreads(first: 100) {
+        nodes {
+          id isResolved path
+          comments(first: 1) { nodes { author { login } body } }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}' | jq '
+  .data.repository.pullRequest.reviewThreads |
+  (.pageInfo | "hasNextPage=\(.hasNextPage) endCursor=\(.endCursor)"),
+  (.nodes[] | select(.isResolved == false))
+'
+```
+
+Reply on a thread, then resolve it:
+
+```sh
+gh api graphql -f query='
+mutation($threadId: ID!, $body: String!) {
+  addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: $threadId, body: $body }) {
+    comment { id }
+  }
+}' -F threadId="PRRT_..." -F body="Fixed in <SHA>: <one-line summary>."
+
+gh api graphql -f query='
+mutation($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) { thread { id isResolved } }
+}' -F threadId="PRRT_..."
+```
+
+Issue-level Copilot comments (those in `issues/<N>/comments`) have no resolution action — GitHub provides no API or UI to resolve them. Reply if the finding warrants it; no resolution step is needed or possible.
+
+Reply-body conventions:
+
+- Accepted bug/style fix: include fixing commit SHA and a one-line summary.
+- Declined style comment: cite the rule (AGENTS.md or CODESTYLE.md) and the existing-tree precedent.
+- Declined architecture proposal: one-sentence rationale.
+
+After the final push, sweep-resolve stale older threads for removed code paths.
+
+---
+
 ## Project Overview
 
 **LanguageTags** is a C# .NET library for handling ISO 639-2, ISO 639-3, and RFC 5646 / BCP 47 language tags. The project serves two primary purposes:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,74 @@
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Every ecosystem appears **twice**: once with `target-branch: "main"`
+# and once with `target-branch: "develop"`. Dependabot will open
+# parallel PRs against each branch, so both stay current on
+# dependency versions independently of the develop → main release
+# cadence.
+#
+# Why dual-target and not develop-only:
+# - `develop` is the integration branch and ships content forward to
+#   `main` through merge-commit releases, but the time between releases
+#   can be long (a feature branch may sit on develop for weeks).
+# - Consumers (NuGet.org, GitHub releases) pull from `main` directly.
+#   If `main` only got dependency bumps via the next develop → main
+#   release, those consumers would ship outdated code in the interim.
+# - The codegen workflow takes the same dual-target shape for the same
+#   reason — see .github/workflows/run-codegen-pull-request-task.yml.
+#
+# The merge-bot's `case` statement in
+# .github/workflows/merge-bot-pull-request.yml dispatches the merge
+# method per base ref (squash on develop, merge on main) so both bases
+# auto-merge cleanly. `develop` remains strictly forward-only: there
+# are no main → develop back-merges; each branch absorbs its own
+# Dependabot PRs and codegen PRs independently.
+#
+# Security update PRs (CVE-driven) are opened by Dependabot against
+# the repo default branch (`main`) regardless of any `target-branch`
+# config — the `case` statement handles them in the same code path.
 version: 2
 updates:
 
-  # main
-- package-ecosystem: "nuget"
-  target-branch: "main"
-  directory: "/"
-  schedule:
-    interval: "daily"
-  groups:
-    nuget-deps:
-      patterns:
-        - "*"
-- package-ecosystem: "github-actions"
-  target-branch: "main"
-  directory: "/"
-  schedule:
-    interval: "daily"
-  groups:
-    actions-deps:
-      patterns:
-        - "*"
+  # ----- nuget -----
+
+  - package-ecosystem: "nuget"
+    target-branch: "main"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      nuget-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "nuget"
+    target-branch: "develop"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      nuget-deps:
+        patterns:
+          - "*"
+
+  # ----- github-actions -----
+
+  - package-ecosystem: "github-actions"
+    target-branch: "main"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "develop"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"

--- a/.github/workflows/build-datebadge-task.yml
+++ b/.github/workflows/build-datebadge-task.yml
@@ -1,8 +1,5 @@
 name: Build BYOB date badge task
 
-env:
-  IS_MAIN_BRANCH: ${{ endsWith(github.ref, 'refs/heads/main') }}
-
 on:
   workflow_call:
 
@@ -17,11 +14,12 @@ jobs:
       - name: Get current date step
         id: date
         run: |
+          set -euo pipefail
           echo "date=$(date)" >> $GITHUB_OUTPUT
 
       - name: Build BYOB date badge step
-        if: ${{ env.IS_MAIN_BRANCH == 'true' }}
-        uses: RubbaBoy/BYOB@v1
+        if: ${{ github.ref_name == 'main' }}
+        uses: RubbaBoy/BYOB@a4919104bc0ec7cfd7f113e42c405cc45246f2a4 # v1
         with:
           name: lastbuild
           label: "Last Build"

--- a/.github/workflows/build-library-task.yml
+++ b/.github/workflows/build-library-task.yml
@@ -1,7 +1,6 @@
 name: Build library task
 
 env:
-  IS_MAIN_BRANCH: ${{ endsWith(github.ref, 'refs/heads/main') }}
   PROJECT_FILE: ./LanguageTags/LanguageTags.csproj
   PROJECT_ARTIFACT: LanguageTags.7z
 
@@ -35,19 +34,20 @@ jobs:
     steps:
 
       - name: Setup .NET SDK step
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 10.x
 
       - name: Checkout code step
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build library project step
         run: |
+          set -euo pipefail
           dotnet build ${{ env.PROJECT_FILE }} \
             -property:OutputPath=${{ runner.temp }}/publish/ \
             -property:PackageOutputPath=${{ runner.temp }}/publish/ \
-            --configuration ${{ env.IS_MAIN_BRANCH == 'true' && 'Release' || 'Debug' }} \
+            --configuration ${{ inputs.push && 'Release' || 'Debug' }} \
             -property:Version=${{ needs.get-version.outputs.AssemblyVersion }} \
             -property:FileVersion=${{ needs.get-version.outputs.AssemblyFileVersion }} \
             -property:AssemblyVersion=${{ needs.get-version.outputs.AssemblyVersion }} \
@@ -57,6 +57,7 @@ jobs:
       - name: Publish to NuGet.org step
         if: ${{ inputs.push }}
         run: |
+          set -euo pipefail
           dotnet nuget push ${{ runner.temp }}/publish/*.nupkg \
             --source https://api.nuget.org/v3/index.json \
             --api-key ${{ secrets.NUGET_API_KEY }} \
@@ -64,11 +65,12 @@ jobs:
 
       - name: Zip output step
         run: |
+          set -euo pipefail
           7z a -t7z ${{ runner.temp }}/${{ env.PROJECT_ARTIFACT }} ${{ runner.temp }}/publish/*
 
       - name: Upload build artifacts step
         id: artifact-upload-step
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: library-build
           path: ${{ runner.temp }}/${{ env.PROJECT_ARTIFACT }}

--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -1,8 +1,5 @@
 name: Build project release task
 
-env:
-  IS_MAIN_BRANCH: ${{ endsWith(github.ref, 'refs/heads/main') }}
-
 on:
   workflow_call:
     inputs:
@@ -41,20 +38,27 @@ jobs:
     steps:
 
       - name: Checkout code step
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Download library build artifacts job
-        uses: actions/download-artifact@v8
+      - name: Download library build artifacts step
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           artifact-ids: ${{ needs.build-library.outputs.artifact-id }}
           path: ./Publish
 
-      - name: Create GitHub release job
-        uses: softprops/action-gh-release@v2
+      # `target_commitish` MUST be set explicitly: softprops doesn't pass a
+      # default through, and GitHub's REST API then defaults the new tag to
+      # the repository's default branch (main). On `push: develop` runs the
+      # tag would land on main's tip instead of the develop commit that
+      # built the artifact, leaving "Browse files" and `git checkout <tag>`
+      # pointing at unrelated code.
+      - name: Create GitHub release step
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true
           tag_name: ${{ needs.get-version.outputs.SemVer2 }}
-          prerelease: ${{ env.IS_MAIN_BRANCH != 'true' }}
+          target_commitish: ${{ github.sha }}
+          prerelease: ${{ github.ref_name != 'main' }}
           files: |
             LICENSE
             README.md

--- a/.github/workflows/get-version-task.yml
+++ b/.github/workflows/get-version-task.yml
@@ -27,15 +27,19 @@ jobs:
     steps:
 
       - name: Setup .NET SDK step
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 10.x
 
       - name: Checkout code step
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
+      # nbgv is intentionally NOT SHA-pinned: the upstream tag stream lags
+      # `master` substantially and Dependabot's tag-tracking would propose
+      # a downgrade. Documented exception to the Workflow YAML Conventions
+      # action-pinning rule in AGENTS.md.
       - name: Run Nerdbank.GitVersioning tool step
         id: nbgv
         uses: dotnet/nbgv@master

--- a/.github/workflows/merge-bot-pull-request.yml
+++ b/.github/workflows/merge-bot-pull-request.yml
@@ -26,8 +26,13 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      # Merge if either condition is true:
+      #   Non-NuGet ecosystems (e.g. github-actions) allow all updates including major (e.g. v2->v3)
+      #   NuGet allows only minor and patch updates, skipping major as they may contain breaking changes
       - name: Merge pull request step
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        if: >-
+          (steps.metadata.outputs.package-ecosystem != 'nuget') ||
+          (steps.metadata.outputs.update-type != 'version-update:semver-major')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/merge-bot-pull-request.yml
+++ b/.github/workflows/merge-bot-pull-request.yml
@@ -1,55 +1,214 @@
 name: Merge bot pull request action
 
+# Three-job model:
+#   1. `merge-dependabot` / `merge-codegen` run on `opened` and `reopened`
+#      events only. They enable auto-merge via `gh pr merge --auto` once
+#      per PR. Restricting to open/reopen (skipping `synchronize`) is what
+#      makes step 3 below stick — if these jobs re-ran on every
+#      `synchronize`, they'd undo a maintainer-triggered disable.
+#   2. The merge method (`--squash` vs `--merge`) is dispatched by a
+#      `case` statement on `pull_request.base.ref` so the form matches
+#      each branch's ruleset (develop = squash-only, main = merge-only,
+#      see AGENTS.md "Branching Model"). Both Dependabot and codegen
+#      open parallel PRs against both branches; Dependabot security
+#      updates always target `main` and flow through the same code path.
+#   3. `disable-auto-merge-on-maintainer-push` runs on `synchronize`
+#      events against bot-authored PRs when the event actor is NOT the
+#      same bot — i.e. a maintainer pushed commits to a bot PR. It
+#      calls `gh pr merge --disable-auto` so the maintainer's commits
+#      don't auto-merge along with the bot's content. The maintainer
+#      re-enables auto-merge manually (UI or `gh pr merge --auto`)
+#      when ready.
+#
+# Token strategy:
+#   Every job uses an App token (`actions/create-github-app-token`).
+#   The resulting push is committed by the App, which fires downstream
+#   workflows on develop and main. `GITHUB_TOKEN`-authored pushes are
+#   blocked from triggering further workflow runs by GitHub's recursion
+#   guard, which would silently skip `publish-release.yml` on the merge
+#   commit. The App-token path also removes the close/reopen dance
+#   previously used by codegen PRs created under `GITHUB_TOKEN` to nudge
+#   the auto-merge workflow. The disable job needs an App token too:
+#   even though the event actor is a maintainer, the workflow context
+#   on a Dependabot PR runs with Dependabot's restricted secrets
+#   regardless of actor, so plain `GITHUB_TOKEN` would be read-only.
+
+# `pull_request_target` rather than `pull_request`: this workflow holds
+# the App private key in env (`GH_TOKEN`) and runs actions
+# (`create-github-app-token`, `fetch-metadata`) that consume it. Under
+# `pull_request` the workflow definition AND the action SHAs come from
+# the PR head — meaning a Dependabot bump of `actions/create-github-app-token`
+# (or any other action used here) would execute the new, unreviewed SHA
+# with full access to the App key. `pull_request_target` runs from the
+# base-branch workflow definition, so action-SHA changes only take effect
+# *after* they're merged. Safe because this workflow never checks out PR
+# code — it only calls `gh pr merge` against the PR by URL, so the usual
+# `pull_request_target` warning about untrusted PR code doesn't apply.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
+# `cancel-in-progress: false` is load-bearing. The three-job model
+# (enable on opened/reopened, disable on maintainer-triggered
+# synchronize) relies on those events running to completion in arrival
+# order. With cancel-in-progress: true, a fast follow-up synchronize
+# (e.g. a Dependabot rebase right after PR open) would cancel the
+# in-flight `opened` run before it reached `gh pr merge --auto`, and
+# the new synchronize run skips the enable jobs (opened/reopened
+# filter), leaving auto-merge never enabled. Queueing instead of
+# cancelling makes the final state deterministic: opened enables,
+# then any subsequent synchronize disables (if maintainer) or no-ops
+# (if bot).
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
 
   merge-dependabot:
     name: Merge dependabot pull request job
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    # Restrict to Dependabot PRs that originate from this repository, not
+    # a fork. Only runs on `opened` / `reopened` events so the auto-merge
+    # enable happens once per PR; the `disable-auto-merge-on-maintainer-push`
+    # job below is what disables auto-merge when a maintainer pushes to a
+    # Dependabot branch. Skipping `synchronize` here is what keeps that
+    # disable sticky.
+    if: >-
+      (github.event.action == 'opened' || github.event.action == 'reopened') &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
       pull-requests: write
 
     steps:
 
+      - name: Generate GitHub App token step
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.CODEGEN_APP_ID }}
+          private-key: ${{ secrets.CODEGEN_APP_PRIVATE_KEY }}
+
       - name: Get dependabot metadata step
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      # Merge if either condition is true:
-      #   Non-NuGet ecosystems (e.g. github-actions) allow all updates including major (e.g. v2->v3)
-      #   NuGet allows only minor and patch updates, skipping major as they may contain breaking changes
+      # Skip semver-major NuGet bumps: majors can build cleanly but break
+      # runtime behavior, so they should land via human review. Other
+      # ecosystems' majors (github-actions) are usually safe and merge.
       - name: Merge pull request step
         if: >-
           (steps.metadata.outputs.package-ecosystem != 'nuget') ||
           (steps.metadata.outputs.update-type != 'version-update:semver-major')
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          set -euo pipefail
+          case "${{ github.event.pull_request.base.ref }}" in
+            develop) method=--squash ;;
+            main) method=--merge ;;
+            *)
+              echo "::error::Unsupported base branch: ${{ github.event.pull_request.base.ref }}"
+              exit 1
+              ;;
+          esac
+          gh pr merge --auto "$method" "$PR_URL"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
   merge-codegen:
     name: Merge codegen pull request job
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'github-actions[bot]' && github.event.pull_request.head.ref == 'codegen' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.full_name == github.repository && ((github.event.action == 'reopened' && github.actor == 'ptr727') || (github.event.action != 'reopened' && github.actor == 'github-actions[bot]'))
+    # Restrict to codegen PRs that originate from the App in this
+    # repository. Codegen runs in a matrix over `main` and `develop`,
+    # so two head refs are valid: `codegen-main` (always targets `main`)
+    # and `codegen-develop` (always targets `develop`). The head/base
+    # pairing is enforced strictly so a misconfigured workflow can't,
+    # for example, sneak a `codegen-develop` branch into `main`.
+    # Only runs on `opened` / `reopened` events so the auto-merge enable
+    # happens once per PR; the `disable-auto-merge-on-maintainer-push`
+    # job below is what disables auto-merge when a maintainer pushes to a
+    # codegen branch. Skipping `synchronize` here is what keeps that
+    # disable sticky.
+    if: >-
+      (github.event.action == 'opened' || github.event.action == 'reopened') &&
+      github.event.pull_request.user.login == 'ptr727-codegen[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        (github.event.pull_request.head.ref == 'codegen-main' && github.event.pull_request.base.ref == 'main') ||
+        (github.event.pull_request.head.ref == 'codegen-develop' && github.event.pull_request.base.ref == 'develop')
+      )
     permissions:
       contents: write
       pull-requests: write
 
     steps:
 
+      - name: Generate GitHub App token step
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.CODEGEN_APP_ID }}
+          private-key: ${{ secrets.CODEGEN_APP_PRIVATE_KEY }}
+
       - name: Merge pull request step
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          set -euo pipefail
+          case "${{ github.event.pull_request.base.ref }}" in
+            develop) method=--squash ;;
+            main) method=--merge ;;
+            *)
+              echo "::error::Unsupported base branch: ${{ github.event.pull_request.base.ref }}"
+              exit 1
+              ;;
+          esac
+          gh pr merge --auto "$method" "$PR_URL"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  disable-auto-merge-on-maintainer-push:
+    name: Disable auto-merge on maintainer push job
+    runs-on: ubuntu-latest
+    # Fires on `synchronize` events against bot-authored PRs (Dependabot
+    # or codegen) when the event actor is NOT the same bot — i.e. a
+    # maintainer pushed commits to the bot's branch. Disables auto-merge
+    # so the maintainer's commits don't auto-merge along with the bot's
+    # content. The maintainer re-enables auto-merge manually when ready
+    # (UI button, or `gh pr merge --auto <PR>`).
+    #
+    # `gh pr merge --disable-auto` is idempotent — calling it on a PR
+    # that already has auto-merge disabled is a no-op.
+    if: >-
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        github.event.pull_request.user.login == 'dependabot[bot]' ||
+        github.event.pull_request.user.login == 'ptr727-codegen[bot]'
+      ) &&
+      github.actor != github.event.pull_request.user.login
+    permissions:
+      pull-requests: write
+
+    steps:
+
+      - name: Generate GitHub App token step
+        # App token rather than GITHUB_TOKEN: on a Dependabot PR the
+        # workflow context runs with Dependabot's restricted secrets
+        # regardless of who triggered the event (GitHub gates by PR
+        # origin, not by event actor), and the restricted GITHUB_TOKEN
+        # is read-only. Same App token pattern as the other merge jobs.
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.CODEGEN_APP_ID }}
+          private-key: ${{ secrets.CODEGEN_APP_PRIVATE_KEY }}
+
+      - name: Disable auto-merge step
+        run: gh pr merge --disable-auto "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/run-codegen-pull-request-task.yml
+++ b/.github/workflows/run-codegen-pull-request-task.yml
@@ -1,62 +1,89 @@
 name: Run codegen and pull request task
 
+# Runs codegen against `main` and `develop` in parallel via a matrix,
+# opens a PR against each base (`codegen-main` branch → main,
+# `codegen-develop` branch → develop). The merge-bot auto-merges
+# either PR independently. This keeps both branches current on
+# generated content without either branch falling behind the other
+# and without main → develop back-merges (see AGENTS.md
+# "Branching Model" for the forward-only develop invariant).
+
 on:
   workflow_call:
     secrets:
-      WORKFLOW_PAT:
+      # GitHub App credentials to generate an installation token
+      CODEGEN_APP_ID:
+        required: true
+      CODEGEN_APP_PRIVATE_KEY:
         required: true
 
 jobs:
 
   codegen:
-    name: Run codegen and pull request job
+    name: Run ${{ matrix.target.ref }} codegen and pull request job
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
+    strategy:
+      # Each branch gets its own parallel codegen run + PR. If one
+      # branch's PR fails (CI, conflicts, etc.) the other is unaffected.
+      fail-fast: false
+      matrix:
+        target:
+          - ref: main
+            branch: codegen-main
+          - ref: develop
+            branch: codegen-develop
 
     steps:
 
+      - name: Generate GitHub App token step
+        # The App-token-driven PR open fires `pull_request` workflow events
+        # directly. `GITHUB_TOKEN`-driven PR opens do not (GitHub's recursion
+        # guard), which previously required a close/reopen dance under a PAT
+        # to nudge the auto-merge workflow — that dance is gone.
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.CODEGEN_APP_ID }}
+          private-key: ${{ secrets.CODEGEN_APP_PRIVATE_KEY }}
+
       - name: Setup .NET SDK step
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 10.x
 
       - name: Checkout code step
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: main
+          ref: ${{ matrix.target.ref }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Run codegen step
         run: |
+          set -euo pipefail
           dotnet run --project ./LanguageTagsCreate/LanguageTagsCreate.csproj -- \
             --codepath .
 
       - name: Format code step
         run: |
+          set -euo pipefail
           dotnet tool restore
           dotnet husky install
           dotnet csharpier format --log-level=debug .
           git status
 
       - name: Create pull request step
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         id: cpr
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          base: main
-          branch: codegen
+          # App token: triggers pull_request workflow events directly, creates verified commits as the app
+          token: ${{ steps.app-token.outputs.token }}
+          base: ${{ matrix.target.ref }}
+          branch: ${{ matrix.target.branch }}
           title: 'Update codegen files'
           body: 'This PR updates the codegen files.'
           commit-message: 'Update codegen files'
           delete-branch: true
           sign-commits: true
-
-      - name: Trigger PR workflows step
-        if: steps.cpr.outputs.pull-request-number != ''
-        run: |
-          PR="${{ steps.cpr.outputs.pull-request-number }}"
-          gh pr close "$PR"
-          gh pr reopen "$PR"
-        env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/run-periodic-codegen-pull-request.yml
+++ b/.github/workflows/run-periodic-codegen-pull-request.yml
@@ -1,4 +1,4 @@
-name: Run weekly CodeGen and Pull Request action
+name: Run weekly codegen and pull request action
 
 on:
   workflow_dispatch:
@@ -7,8 +7,14 @@ on:
     - cron: '0 2 * * MON'
 
 concurrency:
-  # Workflow always checks out and targets main/codegen
-  group: codegen-main
+  # Constant (workflow-name only, no ref) rather than the standard
+  # ${{ github.workflow }}-${{ github.ref }} pattern: the reusable
+  # task this calls always writes to the fixed external branches
+  # `codegen-main` and `codegen-develop` regardless of triggering ref,
+  # so a workflow_dispatch from any non-default ref must NOT run
+  # concurrently with the scheduled (default-branch) run — both would
+  # race updating the same codegen branches and PRs.
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -2,7 +2,7 @@ name: Test pull request action
 
 on:
   pull_request:
-    branches: [ main, develop, codegen ]
+    branches: [ main, develop, codegen-main, codegen-develop ]
   workflow_dispatch:
 
 concurrency:
@@ -25,8 +25,9 @@ jobs:
       [ test-release ]
     if: always()
     steps:
-      - name: Check workflow results
+      - name: Check workflow results step
         run: |
+          set -euo pipefail
           exit_on_result() {
             if [[ "$2" == "failure" || "$2" == "cancelled" ]]; then
               echo "Job '$1' failed or was cancelled."

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -2,7 +2,11 @@ name: Test pull request action
 
 on:
   pull_request:
-    branches: [ main, develop, codegen-main, codegen-develop ]
+    # The `branches:` filter under `pull_request` matches the PR's BASE
+    # branch. `codegen-main` and `codegen-develop` are head-only branches
+    # (the codegen workflow opens PRs *from* them into `main` / `develop`)
+    # so they're never bases — only the protected base branches go here.
+    branches: [ main, develop ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-release-task.yml
+++ b/.github/workflows/test-release-task.yml
@@ -13,15 +13,16 @@ jobs:
     steps:
 
       - name: Setup .NET SDK step
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 10.x
 
       - name: Checkout code step
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check code style step
         run: |
+          set -euo pipefail
           dotnet tool restore
           dotnet husky install
           dotnet husky run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,65 +1,148 @@
 # Instructions for AI Coding Agents
 
-**LanguageTags** is a C# .NET library for handling ISO 639-2, ISO 639-3, and RFC 5646 / BCP 47 language tags.
+**LanguageTags** is a C# .NET library for handling ISO 639-2, ISO 639-3, and RFC 5646 / BCP 47 language tags. The library ships as the NuGet package `ptr727.LanguageTags` and is consumed directly from `main`. The repo also contains a CLI codegen tool (`LanguageTagsCreate/`) that refreshes embedded language data from upstream registries, and an xUnit test project (`LanguageTagsTests/`).
 
-The project serves two primary purposes:
+This file is the canonical reference for cross-cutting AI-agent and workflow rules. C# code-style conventions live in [`CODESTYLE.md`](./CODESTYLE.md). Copilot review *mechanics* are owned by [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) — this file delegates them there explicitly (see "PR Review Etiquette" below). High-level summaries in other docs (e.g. README's Contributing section) are allowed when they link back here; don't duplicate the rules themselves.
 
-1. **Data Publishing**: Provides ISO 639-2, ISO 639-3, and RFC 5646 language tag records in JSON and C# formats
-2. **Tag Processing**: Implements IETF BCP 47 language tag construction and parsing per RFC 5646 semantic rules
+## Git and Commit Rules
 
-For comprehensive coding standards and detailed conventions, refer to [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) and [`CODESTYLE.md`](./CODESTYLE.md).
+**These rules are absolute — no exceptions:**
 
-## Solution Structure
+- **Never make git commits.** AI coding agents cannot produce cryptographically signed commits. All commits must be signed (SSH/GPG) and must be made by the developer. Stage changes with `git add` and leave the commit to the developer.
+- **Never force push.** Do not run `git push --force` or `git push --force-with-lease` under any circumstances. Force pushing rewrites shared history and can cause data loss.
+- **Never run destructive git commands** (`git reset --hard`, `git checkout .`, `git restore .`, `git clean -f`) without explicit developer instruction.
+- **Staging is the limit.** Prepare and stage file changes; the developer runs `git commit` in their own environment where signing keys are available.
 
-### Projects
+## Branching Model
+
+- `develop` is the integration branch. Feature branches → `develop` is **squash-only**; develop is kept linear.
+- `develop` → `main` is **merge-commit only** (no squash, no rebase). Merge commits preserve develop's commit list as a real second-parent reference on main, which is what makes the "release on every push" model attribute releases to the develop commits that produced them. Branch protection enforces this: the develop ruleset allows only `squash`, the main ruleset allows only `merge`.
+- All commits on both branches must be cryptographically signed (SSH or GPG). Squash and merge commits created via the GitHub UI are signed by GitHub's web-flow key.
+- **`develop` is forward-only — no `main → develop` back-merges.** The develop ruleset's squash-only setting physically blocks merge commits on develop. Historical back-merge commits visible in `git log` predate this rule and must not be repeated.
+- **Main ruleset intentionally omits "Require branches to be up to date before merging".** This GitHub branch-protection check is graph-based — it asks whether main's tip commit is reachable from develop, not whether the two branches have the same content. After any develop → main release, main's tip is a brand-new merge commit that develop's history doesn't contain. Forward-only develop never adds it (no back-merge of main into develop), so the check would fail on every subsequent release. The develop ruleset keeps the "up to date" check on (it's normal hygiene for feature → develop merges); only the main ruleset omits it.
+- **Bots (Dependabot and codegen) target both `main` and `develop` in parallel.** [`.github/dependabot.yml`](./.github/dependabot.yml) duplicates every ecosystem entry (one per branch) and [`.github/workflows/run-codegen-pull-request-task.yml`](./.github/workflows/run-codegen-pull-request-task.yml) runs as a matrix over both branches with branch names `codegen-main` and `codegen-develop`. Each branch absorbs its own bot PRs independently, so neither falls behind, and the forward-only rule still holds (nothing is back-merged from main to develop — both branches receive their updates directly). The merge-bot ([`.github/workflows/merge-bot-pull-request.yml`](./.github/workflows/merge-bot-pull-request.yml)) dispatches `--squash` or `--merge` from each PR's base ref via a `case` statement so the form matches the ruleset on either base. Dependabot **security** PRs (CVE-driven) always open against the repo default branch (`main`) regardless of `target-branch` — the same `case` statement covers them.
+- **Maintainer-pushed commits on a bot PR auto-disable auto-merge.** The merge-bot's `merge-dependabot` and `merge-codegen` jobs only fire on `opened` / `reopened` events (auto-merge is enabled exactly once per PR). When a maintainer pushes commits to a bot's branch (a `synchronize` event with an actor that isn't the same bot), the merge-bot's `disable-auto-merge-on-maintainer-push` job fires and calls `gh pr merge --disable-auto`. The maintainer's commits stay in the PR but won't auto-merge with the bot's content; re-enable auto-merge manually (`gh pr merge --auto <PR>` or the GitHub UI) when ready.
+- **Why parallel dual-target rather than develop-only with eventual flow-through:** consumers (NuGet.org, GitHub releases) pull from `main` directly. A develop-only model would leave `main` running stale code during long-running develop features. Codegen content here is the embedded ISO 639-2/3 + RFC 5646 language data — production-critical and refreshed weekly — so both branches need fresh codegen on their own cadence.
+
+## Pull Request Title and Commit Message Conventions
+
+### Format
+
+- Imperative subject summarizing the change, ≤72 characters, no trailing period. ("Add ISO 639-3 retired-code handling", not "Added X" or "Adds X".)
+- Optional body, blank-line separated, explaining *why* the change is being made when that's non-obvious. The diff shows *what*.
+
+### Rules
+
+- Don't write `update stuff`, `wip`, or other vague titles. (Dependabot's default `Bump X from Y to Z` titles are fine — keep them.)
+- Don't add `Co-Authored-By:` lines unless the developer explicitly asks.
+- Don't put release-bump magnitude in the title — no "minor", "patch", "release v0.2.0", etc. Nerdbank.GitVersioning computes the next release version from `version.json` + git history. Dependency versions in dependency-bump titles are fine and expected.
+- Use US English spelling and match the existing heading style of the file you're editing: title case with lowercase short bind words (a, an, the, and, but, or, of, in, on, at, to, by, for, from); hyphenated compounds capitalize both parts unless the second is a short preposition (*Built-in*, *RFC-Compliant*, *24-Hour*).
+
+### Examples
+
+```text
+Add structured logging extensions to LanguageTag
+Pin softprops/action-gh-release to commit SHA
+Refresh ISO 639-3 data table from SIL
+Bump xunit.v3 from 3.2.2 to 3.3.0
+Clarify LanguageTagBuilder usage in README
+```
+
+## Documentation Style Conventions
+
+### Markdown
+
+- Use reference-style links for any URL referenced more than once or appearing in lists; alphabetize the reference definitions block.
+- Inline single-use relative links (e.g. `[CODESTYLE.md](./CODESTYLE.md)`) are fine.
+- One logical paragraph per line; no hard-wrap line-length limit.
+- Headings follow the title-case-with-short-bind-words rule from the PR-title section.
+
+### Quantitative Claims
+
+- Any quantitative claim in `README.md` (counts, sizes, version floors, supported platforms) must be verified against current code. If a doc number is derived from a code constant, mark the dependency in a source-code comment so the next editor knows to update both.
+
+## PR Review Etiquette
+
+The repo runs a review loop on every PR: local agent iteration plus remote automated review (GitHub Copilot is the configured reviewer). Treat this as a contract regardless of which local agent authored the changes.
+
+### Expected Review Loop
+
+1. Push changes to the PR branch.
+2. Confirm a review was requested for the **current head SHA** (auto-trigger is unreliable; request explicitly).
+3. Wait for review activity on that head.
+4. Triage findings.
+5. Apply fixes or write a rationale for declines.
+6. Reply to each thread and resolve what was addressed.
+7. Re-run the loop after every fix push until no actionable findings remain.
+
+`mergeStateStatus: CLEAN` only checks required statuses; it does not block on bot review comments. Merge only after review on the latest head SHA is confirmed and actionable findings are closed.
+
+For provider-specific mechanics (how to request review, query review state, post replies, resolve threads), see the **GitHub Copilot Review Runbook** in [.github/copilot-instructions.md](./.github/copilot-instructions.md). This file owns the contract; that file owns the mechanics.
+
+### Triaging Review Comments
+
+For each comment, classify before responding:
+
+- **Bug** — wrong behavior, missing test coverage, or a real divergence between code and docs. Fix it. Reply with the fixing commit SHA when done.
+- **Style/convention** — the comment cites a rule from this file or a language-specific style guide. Two cases:
+  - The cited rule matches what the existing codebase already does → fix the offending code.
+  - The cited rule contradicts what's in the tree, or industry norm → **update the rule instead of the code**. The rule is wrong, not the code. Bouncing the same code across rounds is the symptom of a wrong rule. Heuristic: three rounds on the same style category means the rule needs adjusting and the user should authorize the rule change.
+- **Architectural opinion** — the comment proposes a different design ("constrain this to disabled-by-default", "move it elsewhere", "add a runtime guardrail"). This is judgement, not a bug. Surface it to the user with a recommendation; don't apply unilaterally.
+
+### Responding and Resolution Expectations
+
+Reply inline with either the fixing commit SHA (for accepted issues) or a concise rationale (for declines). Resolve review threads when addressed or intentionally declined with rationale. Issue-level comments (those at `repos/.../issues/<N>/comments` rather than tied to a specific line) have no resolution action — acknowledge with a reply if needed and move on.
+
+After the final push on a PR, sweep older threads from earlier rounds whose code paths no longer exist; otherwise stale unresolved markers remain in the review UI.
+
+### Escalating to the User
+
+Bring the user in when:
+
+- **Genuine design trade-off** surfaces (fail-open vs fail-closed, narrow vs broad refactor scope, "should we add a guardrail or trust the docstring"). Triage, recommend, ask.
+- **Repeated friction** across rounds without convergence — that's the rule-needs-updating signal. Stop, summarize the pattern, and let the user authorize the rule change.
+- **Architectural redesign** is requested rather than a bug fix. Surface with a recommendation; never apply unilaterally.
+
+Anti-pattern: don't keep flipping the code on the same style point. Flip the rule once and stick to the rule.
+
+## Workflow YAML Conventions
+
+These conventions describe the target state. New and modified workflows must respect them; the rest of the repo is expected to be brought up to the same standard.
+
+- **Action pinning**: pin **every** action — first-party (`actions/*`) and third-party — to a commit SHA with a trailing `# vX.Y.Z` comment, so Dependabot can still bump it but a tag swap can't change the executed code. Use `# vX` (major-only) only when the upstream's floating major tag doesn't correspond to a specific patch/minor release SHA — pinning to the floating-tag SHA still gives the SHA guarantee, the version comment just records the major line. Documented exception (no SHA pin at all): [`dotnet/nbgv`](./.github/workflows/get-version-task.yml) is consumed via `@master` because the upstream tag stream lags `master` substantially and Dependabot's tag-tracking would propose a downgrade — the rationale is documented inline in that workflow.
+- **Filename**: reusable workflows (those with `on: workflow_call`) end in `-task.yml`. Entry-point workflows (`on: push` / `pull_request` / `schedule` / `workflow_dispatch`) do NOT use the `-task` suffix; they end with what they do — `-pull-request.yml`, `-release.yml`, etc. The suffix carries semantic meaning: a `-task.yml` file is meant to be `uses:`-d, never triggered directly.
+- **Workflow `name:`** (the top-level `name:` field): reusable workflow names end in **"task"** (e.g. `Build library task`); entry-point workflow names end in **"action"** (e.g. `Publish project release action`, `Test pull request action`). The displayed action name in the GitHub Actions UI tells you at a glance whether you're looking at an orchestrator or a callee.
+- **Job and step `name:` suffixes**: every job's `name:` ends in **"job"**; every step's `name:` ends in **"step"**. **Exception**: a job whose `name:` is also referenced as a required-status-check `context:` in a branch ruleset (currently `Check pull request workflow status` in `test-pull-request.yml`) keeps the ruleset-bound name verbatim — renaming would silently break required-status-check enforcement. Do not "fix" that name; if a future job becomes ruleset-bound, mark it the same way.
+- **Concurrency**: top-level workflows declare `concurrency: { group: '${{ github.workflow }}-${{ github.ref }}', cancel-in-progress: true }` so a fresh push supersedes an in-flight run on the same ref. **Documented exception**: [`merge-bot-pull-request.yml`](./.github/workflows/merge-bot-pull-request.yml) uses `cancel-in-progress: false` because its three-job model (enable-auto-merge on opened, disable-auto-merge on maintainer-pushed synchronize, with method dispatched by base) requires each event to run to completion in arrival order. Cancellation would leave auto-merge in an inconsistent state. The rationale is recorded inline in that workflow's header comment.
+- **Shells**: multi-line `run:` blocks with bash start with `set -euo pipefail` — fail fast, fail on undefined vars, fail on a failed pipe segment.
+- **Conditionals**: multi-line `if:` uses folded scalar `if: >-` so YAML preserves whitespace correctly. Literal block (`if: |`) is wrong because it embeds newlines inside the boolean expression.
+- **Boolean inputs**: workflows triggered both via `workflow_call` and `workflow_dispatch` must declare each boolean input in *both* trigger blocks — one definition does not propagate to the other. `workflow_call` delivers booleans as actual booleans; `workflow_dispatch` delivers them as the *strings* `"true"`/`"false"`. Any `if:` consuming a boolean input must compare against both forms — `if: ${{ inputs.foo == true || inputs.foo == 'true' }}`.
+- **Reusable workflows**: job-level `permissions:` are validated *before* the `if:` evaluates, so even a skipped job needs valid permissions declared. A `release` job with `permissions: contents: write` and `if: ${{ inputs.publish }}` will still cause `startup_failure` on a caller that doesn't grant `contents: write`. Either declare permissions at the call site, or omit the inner block and inherit.
+- **Allowlist `success` and `skipped` explicitly** when chaining jobs across optional dependencies — `!= 'failure'` lets `cancelled` through (timeout, runner failure, manual cancel). Use `(needs.X.result == 'success' || needs.X.result == 'skipped')`.
+- **Tag pinning on releases**: when using `softprops/action-gh-release` (or any tag-creating action), pass `target_commitish: ${{ github.sha }}` explicitly. Without it, GitHub's REST API defaults the new tag to the repository's default branch instead of the commit that built the artifact.
+
+## Project Structure
 
 - **LanguageTags** (`LanguageTags/LanguageTags.csproj`)
-  - Core library project
-  - NuGet package: `ptr727.LanguageTags`
-  - Target framework: .NET 10.0
-  - AOT compatible (`<IsAotCompatible>true</IsAotCompatible>`)
-
+  - Core library project, published as NuGet `ptr727.LanguageTags`
+  - Target framework: .NET 10.0, AOT compatible (`<IsAotCompatible>true</IsAotCompatible>`)
 - **LanguageTagsCreate** (`LanguageTagsCreate/LanguageTagsCreate.csproj`)
-  - CLI utility for downloading and generating language data
-  - Downloads from official sources (Library of Congress, SIL, IANA)
-  - Converts to JSON and generates C# code files
-
+  - CLI codegen tool. Downloads ISO 639-2/3 + RFC 5646 / BCP 47 data from official sources (Library of Congress, SIL, IANA), converts to JSON, and generates C# data files. Invoked by [`.github/workflows/run-codegen-pull-request-task.yml`](./.github/workflows/run-codegen-pull-request-task.yml).
 - **LanguageTagsTests** (`LanguageTagsTests/LanguageTagsTests.csproj`)
-  - xUnit test suite with comprehensive test coverage
-  - Uses AwesomeAssertions for test assertions
+  - xUnit v3 test suite. Assertions via AwesomeAssertions.
+- **`LanguageData/`** — embedded ISO/RFC data files refreshed by the codegen tool.
+- **Build configuration**:
+  - Common MSBuild properties (`TargetFramework`, `Nullable`, `ImplicitUsings`, `AnalysisLevel`, etc.) live in `Directory.Build.props` at the solution root. Do not duplicate these in individual `.csproj` files — only add a property to a `.csproj` when it is project-specific or overrides the shared default.
+  - All NuGet package versions are centralised in `Directory.Packages.props`. `PackageReference` elements in `.csproj` files must not include a `Version` attribute. Asset metadata (`PrivateAssets`, `IncludeAssets`) stays in the `.csproj` `PackageReference` element.
+- **Style guide**: [`CODESTYLE.md`](./CODESTYLE.md) for C# code conventions; [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) for the Copilot review runbook and the library's public-API contract notes.
 
-### Project Configuration
+## Key Public API
 
-- Common MSBuild properties (`TargetFramework`, `Nullable`, `ImplicitUsings`, `AnalysisLevel`, etc.)
-  live in `Directory.Build.props` at the solution root. Do not duplicate these in individual `.csproj`
-  files — only add a property to a `.csproj` when it is project-specific or overrides the shared default.
-- All NuGet package versions are centralised in `Directory.Packages.props`. `PackageReference` elements
-  in `.csproj` files must not include a `Version` attribute. Asset metadata (`PrivateAssets`,
-  `IncludeAssets`) stays in the `.csproj` `PackageReference` element.
+- `LanguageTag` — main entry point for parse/build/normalize/validate operations.
+- `LanguageTagBuilder` — fluent builder for constructing tags.
+- `LanguageLookup` — language code conversion and matching (IETF ↔ ISO).
+- `Iso6392Data`, `Iso6393Data`, `Rfc5646Data` — language data records (`Create()`, `FromDataAsync()`, `FromJsonAsync()`).
+- `ExtensionTag`, `PrivateUseTag` — sealed records for extension and private-use subtags.
+- `LogOptions` — static class for configuring library-wide logging via `ILoggerFactory`.
 
-### Key Components
-
-**Public API Classes:**
-
-- `LanguageTag`: Main class for working with language tags (parse, build, normalize, validate)
-- `LanguageTagBuilder`: Fluent builder for constructing language tags
-- `LanguageLookup`: Language code conversion and matching (IETF ↔ ISO)
-- `Iso6392Data`: ISO 639-2 language code data (`Create()`, `FromDataAsync()`, `FromJsonAsync()`)
-- `Iso6393Data`: ISO 639-3 language code data (`Create()`, `FromDataAsync()`, `FromJsonAsync()`)
-- `Rfc5646Data`: RFC 5646 / BCP 47 language subtag registry data (`Create()`, `FromDataAsync()`, `FromJsonAsync()`)
-- `ExtensionTag`: Represents extension subtags (sealed record)
-- `PrivateUseTag`: Represents private use subtags (sealed record)
-- `LogOptions`: Static class for configuring library-wide logging via `ILoggerFactory`
-
-**Internal Classes:**
-
-- `LanguageTagParser`: Internal parser implementation (use `LanguageTag.Parse()` instead)
-
-## Authoritative References
-
-For detailed specifications, see:
-
-- [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) - Complete coding conventions and style guide
-- [`CODESTYLE.md`](./CODESTYLE.md) - Code style and formatting rules
-- [`.editorconfig`](./.editorconfig) - Automated style enforcement
-- Project task definitions - `CSharpier Format`, `.Net Build`, `.Net Format`, `Husky.Net Run`
+Internal: `LanguageTagParser` — use `LanguageTag.Parse()` instead.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ See [Usage](#usage) for detailed usage instructions.
   - [Installation](#installation)
   - [Questions or Issues](#questions-or-issues)
   - [Build Artifacts](#build-artifacts)
+  - [Contributing](#contributing)
   - [Tag Theory](#tag-theory)
     - [Terminology](#terminology)
     - [Format](#format)
@@ -416,6 +417,32 @@ LogOptions.SetFactory(loggerFactory);
   - ISO 639-3: [Source](https://iso639-3.sil.org/sites/iso639-3/files/downloads/iso-639-3.tab), [Data](./LanguageData/iso6393), [JSON](./LanguageData/iso6393.json), [Code](./LanguageTags/Iso6393DataGen.cs)
   - RFC 5646 : [Source](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry), [Data](./LanguageData/rfc5646), [JSON](./LanguageData/rfc5646.json), [Code](./LanguageTags/Rfc5646DataGen.cs)
 - A weekly [GitHub Actions](./.github/workflows/run-periodic-codegen-pull-request.yml) job keeps the data files up to date and automatically publishes new releases.
+
+## Contributing
+
+**Branching workflow**:
+
+The repo uses a two-branch model with strict ruleset-enforced merge methods:
+
+- Feature branch → `develop` via **squash merge** (develop is kept linear).
+- `develop` → `main` via **merge commit** (preserves develop's commit list on main as the second parent of each release commit).
+- `develop` is **forward-only** — there are no `main → develop` back-merges. Dependabot and the weekly codegen workflow both target `main` and `develop` in parallel via separate PRs.
+
+See [`AGENTS.md`](./AGENTS.md) for the complete branching, PR, and workflow conventions and [`CODESTYLE.md`](./CODESTYLE.md) for C# code style rules.
+
+**Repository setup**:
+
+CI/CD relies on these secrets being configured on the repo:
+
+- `CODEGEN_APP_ID` and `CODEGEN_APP_PRIVATE_KEY` — GitHub App credentials used by the codegen and merge-bot workflows. Must be present in **both** the Actions secret store **and** the Dependabot secret store (the merge-bot runs under Dependabot's restricted secret context on Dependabot PRs).
+- `NUGET_API_KEY` — NuGet.org API key for package publishing. Actions store only.
+
+Branch protection is split across two rulesets:
+
+- **Develop** ruleset: squash-only, linear history, "branches up to date" check on, signed commits required.
+- **Main** ruleset: merge-commit only, linear history off, "branches up to date" check off (forward-only develop makes this check incompatible with the merge-commit release shape), signed commits required.
+
+Both rulesets require the `Check pull request workflow status` status check and request Copilot review on every push.
 
 ## Tag Theory
 


### PR DESCRIPTION
## Summary

First develop → main release under the new merge-commit shape (Main ruleset, configured 2026-05-12).

Brings to main:

- **#130** — Sync repo CI/CD and docs to ProjectTemplate standards: dual-target Dependabot + codegen, three-job merge-bot with App token and branch-aware merge, `pull_request_target` trigger on merge-bot, all actions SHA-pinned, `target_commitish` on releases, build config gated on `inputs.push`, AGENTS.md + Copilot Review Runbook + Contributing section.
- **#122** — earlier merge-bot iteration (pre-existing on develop).
- The prior `Merge branch 'main' into develop` knot (pre-existing) — last back-merge before the forward-only rule kicked in; future releases will not produce these.

After this lands, the obsolete `WORKFLOW_PAT` secret and `codegen` branch can be deleted.

## Test plan

- [ ] CI green on the PR.
- [ ] Merge-commit (not squash) accepted by Main ruleset.
- [ ] `publish-release.yml` fires on the merge commit; resulting GitHub release tags the actual main HEAD SHA (verifies `target_commitish` change).
- [ ] NuGet publish happens with Release configuration (verifies build-config gate change).
- [ ] Next Dependabot run opens parallel PRs against main and develop.
- [ ] Next periodic codegen run opens `codegen-main` → main and `codegen-develop` → develop.
