### PR TITLE
Drop codegen-* heads from test-pull-request branches filter

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -2,7 +2,11 @@ name: Test pull request action
 
 on:
   pull_request:
-    branches: [ main, develop, codegen-main, codegen-develop ]
+    # The `branches:` filter under `pull_request` matches the PR's BASE
+    # branch. `codegen-main` and `codegen-develop` are head-only branches
+    # (the codegen workflow opens PRs *from* them into `main` / `develop`)
+    # so they're never bases — only the protected base branches go here.
+    branches: [ main, develop ]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Addresses Copilot review finding on PR #131: `branches:` under `pull_request` matches the PR's *base* branch, and `codegen-main`/`codegen-develop` are head-only branches by design (never a PR base), so listing them was redundant. Restricts the list to the protected base branches.