### PR TITLE
Rename CODEGEN_APP_ID references to CODEGEN_APP_CLIENT_ID

### DIFF
--- a/.github/workflows/merge-bot-pull-request.yml
+++ b/.github/workflows/merge-bot-pull-request.yml
@@ -88,7 +88,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
-          app-id: ${{ secrets.CODEGEN_APP_ID }}
+          app-id: ${{ secrets.CODEGEN_APP_CLIENT_ID }}
           private-key: ${{ secrets.CODEGEN_APP_PRIVATE_KEY }}
 
       - name: Get dependabot metadata step
@@ -151,7 +151,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
-          app-id: ${{ secrets.CODEGEN_APP_ID }}
+          app-id: ${{ secrets.CODEGEN_APP_CLIENT_ID }}
           private-key: ${{ secrets.CODEGEN_APP_PRIVATE_KEY }}
 
       - name: Merge pull request step
@@ -204,7 +204,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
-          app-id: ${{ secrets.CODEGEN_APP_ID }}
+          app-id: ${{ secrets.CODEGEN_APP_CLIENT_ID }}
           private-key: ${{ secrets.CODEGEN_APP_PRIVATE_KEY }}
 
       - name: Disable auto-merge step

--- a/.github/workflows/run-codegen-pull-request-task.yml
+++ b/.github/workflows/run-codegen-pull-request-task.yml
@@ -12,7 +12,7 @@ on:
   workflow_call:
     secrets:
       # GitHub App credentials to generate an installation token
-      CODEGEN_APP_ID:
+      CODEGEN_APP_CLIENT_ID:
         required: true
       CODEGEN_APP_PRIVATE_KEY:
         required: true
@@ -46,7 +46,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
-          app-id: ${{ secrets.CODEGEN_APP_ID }}
+          app-id: ${{ secrets.CODEGEN_APP_CLIENT_ID }}
           private-key: ${{ secrets.CODEGEN_APP_PRIVATE_KEY }}
 
       - name: Setup .NET SDK step

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ See [`AGENTS.md`](./AGENTS.md) for the complete branching, PR, and workflow conv
 
 CI/CD relies on these secrets being configured on the repo:
 
-- `CODEGEN_APP_ID` and `CODEGEN_APP_PRIVATE_KEY` — GitHub App credentials used by the codegen and merge-bot workflows. Must be present in **both** the Actions secret store **and** the Dependabot secret store (the merge-bot runs under Dependabot's restricted secret context on Dependabot PRs).
+- `CODEGEN_APP_CLIENT_ID` and `CODEGEN_APP_PRIVATE_KEY` — GitHub App credentials used by the codegen and merge-bot workflows. Must be present in **both** the Actions secret store **and** the Dependabot secret store (the merge-bot runs under Dependabot's restricted secret context on Dependabot PRs). The `_CLIENT_ID` half holds the GitHub App's Client ID (e.g. `Iv23li…`); `actions/create-github-app-token` accepts either a numeric App ID or a Client ID at its `app-id` input.
 - `NUGET_API_KEY` — NuGet.org API key for package publishing. Actions store only.
 
 Branch protection is split across two rulesets:


### PR DESCRIPTION
The GitHub App credential secret is stored as `CODEGEN_APP_CLIENT_ID` in both Actions and Dependabot stores, but the workflows that landed in #130 referenced `CODEGEN_APP_ID` (the template's name). With the wrong name, `actions/create-github-app-token` gets an empty `app-id` and the merge-bot + codegen fail on first invocation. `actions/create-github-app-token` v1.12+ accepts either an App ID or a Client ID at the `app-id` input, so this is a pure secret-lookup fix.