### PR TITLE
Fix pre-release badges to actually track pre-releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ C# .NET library for ISO 639-2, ISO 639-3, RFC 5646 / BCP 47 language tags.
 
 [![GitHub Release][releaseversion-shield]][releases-link]\
 [![GitHub Pre-Release][prereleaseversion-shield]][releases-link]\
-[![NuGet Release][nugetreleaseversion-shield]][nuget-link]\
-[![NuGet Pre-Release][nugetprereleaseversion-shield]][nuget-link]
+[![NuGet Release][nugetreleaseversion-shield]][nuget-link]
 
 ### Release Notes
 
@@ -585,12 +584,11 @@ Licensed under the [MIT License][license-link]\
 [lastcommit-shield]: https://img.shields.io/github/last-commit/ptr727/LanguageTags?logo=github&label=Last%20Commit
 
 [releaseversion-shield]: https://img.shields.io/github/v/release/ptr727/LanguageTags?logo=github&label=GitHub%20Release
-[prereleaseversion-shield]: https://img.shields.io/github/v/release/ptr727/LanguageTags?include_prereleases&label=GitHub%20Pre-Release&logo=github
+[prereleaseversion-shield]: https://img.shields.io/github/v/release/ptr727/LanguageTags?include_prereleases&filter=*-g*&label=GitHub%20Pre-Release&logo=github
 [releasebuildstatus-shield]: https://img.shields.io/github/actions/workflow/status/ptr727/LanguageTags/publish-release.yml?logo=github&label=Releases%20Build
 
 [nuget-link]: https://www.nuget.org/packages/ptr727.LanguageTags/
 [nugetreleaseversion-shield]: https://img.shields.io/nuget/v/ptr727.LanguageTags?logo=nuget&label=NuGet%20Release
-[nugetprereleaseversion-shield]: https://img.shields.io/nuget/vpre/ptr727.LanguageTags?logo=nuget&&label=NuGet%20Pre-Release&color=orange
 
 <!-- 3rd Party tool links -->
 


### PR DESCRIPTION
## Summary

- Adds `&filter=*-g*` to the `prereleaseversion-shield` URL in [README.md](./README.md) so the **GitHub Pre-Release** badge filters to tags with the Nerdbank `-g<short-sha>` suffix only.
- Drops the **NuGet Pre-Release** badge entirely (both the in-body usage and the link-reference definition). Shields' NuGet endpoint does not accept a filter; no clean fix exists.

## Why

Observed after [#144](https://github.com/ptr727/LanguageTags/pull/144) merged: the **GitHub Pre-Release** badge displayed `v1.2.42` (a full release), even though the actual latest pre-release at the time was `1.2.40-g0f69a1b0a0`. Same for the **NuGet Pre-Release** badge.

Root cause is shields.io semantics:

- `github/v/release/...?include_prereleases` and `nuget/vpre/...` both mean *"include pre-releases as candidates and return the latest by published date / highest version"* — not *"show pre-releases only"*.
- After every develop → main release merge, Nerdbank.GitVersioning publishes a full release with a height higher than any preceding pre-release, so both pre-release badges converge to their release-only siblings within seconds.

For GitHub there's a clean fix: shields.io's `github/v/release` endpoint accepts a `filter` glob. The Nerdbank short-sha suffix `-g<10hex>` only appears on pre-release tags, so `filter=*-g*` cleanly selects pre-releases.

For NuGet there isn't:

- The NuGet shield ignores `filter` silently.
- The `dynamic/json` shield rejects JSONPath filter predicates (`query not supported`).
- NuGet's flat-container index is semver-sorted (pre-releases ahead of their stable counterparts), so `$.versions[-1]` lands on the same stable.

No way to filter to pre-releases only without a custom hosted endpoint. Dropping it is cleaner than carrying a redundant badge — the GitHub Pre-Release badge now carries the develop-side signal on its own.

## Verification

Hit the new shield URLs directly:

- GitHub Pre-Release with `filter=*-g*` → `v1.2.40-g0f69a1b0a0` ✓
- GitHub Release (unchanged) → `v1.2.42` ✓

## Upstream

The upstream `ptr727/ProjectTemplate` README likely carries the same badge pattern and the same bug. A separate issue will be filed there with details for replication.

## Test plan

- [ ] Copilot review on the current head — no factual / phrasing pushback.
- [ ] `Check pull request workflow status` green.
- [ ] After the next pre-release publish on develop, the GitHub Pre-Release badge updates to the new pre-release tag (not the latest stable).