### PR TITLE
Release: pre-release badges actually track pre-releases (#145)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ C# .NET library for ISO 639-2, ISO 639-3, RFC 5646 / BCP 47 language tags.
 
 [![GitHub Release][releaseversion-shield]][releases-link]\
 [![GitHub Pre-Release][prereleaseversion-shield]][releases-link]\
-[![NuGet Release][nugetreleaseversion-shield]][nuget-link]\
-[![NuGet Pre-Release][nugetprereleaseversion-shield]][nuget-link]
+[![NuGet Release][nugetreleaseversion-shield]][nuget-link]
 
 ### Release Notes
 
@@ -585,12 +584,11 @@ Licensed under the [MIT License][license-link]\
 [lastcommit-shield]: https://img.shields.io/github/last-commit/ptr727/LanguageTags?logo=github&label=Last%20Commit
 
 [releaseversion-shield]: https://img.shields.io/github/v/release/ptr727/LanguageTags?logo=github&label=GitHub%20Release
-[prereleaseversion-shield]: https://img.shields.io/github/v/release/ptr727/LanguageTags?include_prereleases&label=GitHub%20Pre-Release&logo=github
+[prereleaseversion-shield]: https://img.shields.io/github/v/release/ptr727/LanguageTags?include_prereleases&filter=*-g*&label=GitHub%20Pre-Release&logo=github
 [releasebuildstatus-shield]: https://img.shields.io/github/actions/workflow/status/ptr727/LanguageTags/publish-release.yml?logo=github&label=Releases%20Build
 
 [nuget-link]: https://www.nuget.org/packages/ptr727.LanguageTags/
 [nugetreleaseversion-shield]: https://img.shields.io/nuget/v/ptr727.LanguageTags?logo=nuget&label=NuGet%20Release
-[nugetprereleaseversion-shield]: https://img.shields.io/nuget/vpre/ptr727.LanguageTags?logo=nuget&&label=NuGet%20Pre-Release&color=orange
 
 <!-- 3rd Party tool links -->
 


### PR DESCRIPTION
## Summary

Brings develop forward into main. Net effect on main's content is `README.md` only — the badge fixes from [#145](https://github.com/ptr727/LanguageTags/pull/145):

- `prereleaseversion-shield` URL gains `&filter=*-g*` so the **GitHub Pre-Release** badge filters to Nerdbank's `-g<short-sha>` pre-release tags instead of converging to the latest stable after every release.
- The **NuGet Pre-Release** badge (usage and link-reference) is dropped — shields' NuGet endpoint doesn't support filtering and no clean fix exists.

`git diff origin/main..origin/develop --stat`:

```
 README.md | 6 ++----
 1 file changed, 2 insertions(+), 4 deletions(-)
```

## Why this release

After [#144](https://github.com/ptr727/LanguageTags/pull/144) landed today, the "GitHub Pre-Release" badge displayed `v1.2.42` (the full release from #144) while the actual latest pre-release was `1.2.40-g0f69a1b0a0`. Same for the NuGet badge. Root cause: `include_prereleases` and `vpre` mean *include pre-releases as candidates*, not *show pre-releases only* — so Nerdbank's monotonically-increasing height makes the stable always win after a release merge.

The upstream template carries the same bug; tracked at [ptr727/ProjectTemplate#83](https://github.com/ptr727/ProjectTemplate/issues/83) with the full fix recipe.

## Test plan

- [ ] Copilot review on the current head — no factual / phrasing pushback.
- [ ] `Check pull request workflow status` green.
- [ ] After this release publishes (full release on main), the GitHub Pre-Release badge stays on the latest develop-side `-g<sha>` tag rather than converging to the new stable.