### PR TITLE
Migrate deprecated app-id to client-id for GitHub App token

### DIFF
--- a/.github/workflows/merge-bot-pull-request.yml
+++ b/.github/workflows/merge-bot-pull-request.yml
@@ -88,7 +88,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.CODEGEN_APP_CLIENT_ID }}
+          client-id: ${{ secrets.CODEGEN_APP_CLIENT_ID }}
           private-key: ${{ secrets.CODEGEN_APP_PRIVATE_KEY }}
 
       - name: Get dependabot metadata step
@@ -151,7 +151,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.CODEGEN_APP_CLIENT_ID }}
+          client-id: ${{ secrets.CODEGEN_APP_CLIENT_ID }}
           private-key: ${{ secrets.CODEGEN_APP_PRIVATE_KEY }}
 
       - name: Merge pull request step
@@ -204,7 +204,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.CODEGEN_APP_CLIENT_ID }}
+          client-id: ${{ secrets.CODEGEN_APP_CLIENT_ID }}
           private-key: ${{ secrets.CODEGEN_APP_PRIVATE_KEY }}
 
       - name: Disable auto-merge step

--- a/.github/workflows/run-codegen-pull-request-task.yml
+++ b/.github/workflows/run-codegen-pull-request-task.yml
@@ -46,7 +46,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.CODEGEN_APP_CLIENT_ID }}
+          client-id: ${{ secrets.CODEGEN_APP_CLIENT_ID }}
           private-key: ${{ secrets.CODEGEN_APP_PRIVATE_KEY }}
 
       - name: Setup .NET SDK step


### PR DESCRIPTION
`actions/create-github-app-token` deprecated the numeric `app-id` input in v3.0.0, and the scheduled/codegen runs log `Input 'app-id' has been deprecated`. This switches all four call sites to `client-id`:

- `.github/workflows/merge-bot-pull-request.yml` - 3 jobs (merge-dependabot, merge-codegen, disable-auto-merge-on-maintainer-push)
- `.github/workflows/run-codegen-pull-request-task.yml` - 1 job (codegen)

The `CODEGEN_APP_CLIENT_ID` secret already holds the App's Client ID (it was already wired to these steps), so **no secrets change is required** - this is a parameter rename only.

Ports the fix already applied upstream in the ProjectTemplate (`ptr727/ProjectTemplate` issue #88).