### PR TITLE
Bump version to 1.3 for next prerelease cycle

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-	"version": "1.2",
+	"version": "1.3",
 	"publicReleaseRefSpec": [
 		"^refs/heads/main$"
 	],


### PR DESCRIPTION
Isolated version bump establishing the develop-leads invariant: raises `develop`'s minor from `1.2` to `1.3` so develop's NBGV prereleases sort above main's last stable `1.2.x`. Standalone version-only change per the versioning policy.