### PR TITLE
Re-sync from upstream template and move API rules into AGENTS.md

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -48,6 +48,9 @@ end_of_line = lf
 [*.{cmd,bat,ps1}]
 end_of_line = crlf
 
+# --- .NET-only below: C# and ReSharper style. Everything above is the line-ending
+# governance every derived repo carries; a non-.NET repo may drop from here down. ---
+
 # C# files
 [*.cs]
 end_of_line = crlf

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 The **canonical guide is [AGENTS.md](../AGENTS.md)** at the repo root - read it first, including the [PR Review Etiquette](../AGENTS.md#pr-review-etiquette) review-loop contract this file's runbook implements. This file is intentionally narrow: commit/PR-title conventions (summarized inline so VS Code's commit-message and PR-title generators have them) plus the GitHub Copilot Review Runbook.
 
-For C# style rules, see [`CODESTYLE.md`](../CODESTYLE.md) at the repo root. Do not duplicate those rules here.
+For C# style rules, see [`CODESTYLE.md`](../CODESTYLE.md) at the repo root. Do not duplicate those rules here. **Project-specific conventions and API/behavioral contracts also belong in [AGENTS.md](../AGENTS.md), not here** - this file is intentionally limited to the inline commit/PR-title summary and the GitHub Copilot Review Runbook. Non-Copilot agents (Claude Code, Codex, Cursor, ...) are not directed to this file and don't read it by default, so any rule a reviewer must honor has to live in `AGENTS.md` to be provider-independent.
 
 ## Commit Messages and Pull Request Titles
 
@@ -21,6 +21,10 @@ Use this section for provider-specific mechanics. The expected review loop *cont
 ### Triggering and Polling
 
 Auto-review on push is configured (via the branch ruleset's `copilot_code_review` rule with `review_on_push: true`) but fires inconsistently in practice - treat it as best-effort, not guaranteed. After every push, **re-request a review programmatically** via the GraphQL `requestReviews` mutation, passing the Copilot reviewer's bot node id in `botIds`. This drives the loop end-to-end without a UI hand-off.
+
+**A review with no inline comments is still a completed review - not a failure, and not a reason to ask the maintainer to re-trigger.** Copilot very often posts a single formal review (GraphQL `state: COMMENTED`) whose body ends with "...reviewed N of N changed files ... and generated no comments" and adds **zero** inline threads. That review carries the head `commit.oid` and fully satisfies the loop - it is the clean-pass success case. Never read "no inline comments" as "the review didn't run," and never re-request or escalate to the maintainer because comments are absent.
+
+**Round 1 is normally auto-seeded - poll for it before trying to self-trigger.** Auto-review-on-open supplies the first review with no `botIds` call needed, but it can lag one to three minutes. After opening a PR (or the first push), **poll** for a Copilot review on the head SHA (see [Verify Review Covered Current Head](#verify-review-covered-current-head)) before concluding none ran. The `requestReviews` mutation below is for **re-requesting on later pushes** (a new head SHA); by then a prior review exists, so its bot node id is readable. A missing bot node id on round 1 therefore means "the auto-review has not landed yet - wait and poll," **not** "ask the maintainer to kick it off."
 
 > **The reviewer login differs by API.** In **GraphQL** (`gh api graphql` and `gh pr view --json reviews`, which is GraphQL-backed) the `Bot.login` is `copilot-pull-request-reviewer` - **no `[bot]` suffix**. In the **REST** API (`gh api repos/.../issues|pulls/...`) the same account's `user.login` is `copilot-pull-request-reviewer[bot]` - **with** the suffix. Each query below uses the correct form for its API; match the API, not a single spelling, when adapting them.
 
@@ -48,7 +52,7 @@ mutation($pr: ID!, $bot: ID!) {
 }' -F pr="$PR_NODE" -F bot="$BOT_ID"
 ```
 
-The bot node id is read from an existing Copilot review, so step 1 needs at least one prior review on the PR - the auto-review-on-open normally supplies the first one. If no Copilot review exists yet and auto-review didn't fire, request `Copilot` once through the GitHub PR UI to seed it, then use the mutation for every subsequent re-request.
+The bot node id is read from an existing Copilot **formal** review (`pullRequest.reviews`), so step 1 needs at least one prior formal review on the PR - the auto-review-on-open normally supplies the first one (it may have **no inline comments**; that still counts, and its bot node id is still readable). Poll for it (give auto-review-on-open a few minutes) before deciding it is missing. If Copilot posted **only an issue comment** and no formal review, the head is covered but `reviews` yields no bot node id - read the id from the Copilot issue comment's author by querying the PR's issue comments in GraphQL (`pullRequest.comments` -> author `... on Bot { id }`), or request `Copilot` once through the GitHub PR UI to produce a formal review. Manual UI seeding is the fallback specifically when no formal review exists to read the id from; then use the mutation for every subsequent re-request.
 
 **Do NOT post `@Copilot review` as a PR comment.** That comment triggers the Copilot *coding agent* (`copilot-swe-agent[bot]`), which makes code changes rather than posting a review.
 
@@ -75,9 +79,11 @@ gh api repos/ptr727/LanguageTags/issues/<N>/comments --jq \
   '[.[] | select(.user.login=="copilot-pull-request-reviewer[bot]")] | last | {created_at, body: .body[:200]}'
 ```
 
-Coverage is confirmed when (1) exits 0. For issue comments (path 2), body content is the only reliable signal - `created_at` is not: `git log -1 --format=%cI` is the **commit** timestamp, not the push timestamp, so amended or rebased commits can have an earlier timestamp and an older Copilot comment could satisfy a time check even though Copilot never saw the current head. Treat path (2) as confirmed only when the comment body explicitly refers to the current changes.
+Coverage is confirmed when (1) exits 0 - **a formal review with no inline comments still satisfies path (1)**, because coverage is about the head SHA, not the comment count. For issue comments (path 2), body content is the only reliable signal - `created_at` is not: `git log -1 --format=%cI` is the **commit** timestamp, not the push timestamp, so amended or rebased commits can have an earlier timestamp and an older Copilot comment could satisfy a time check even though Copilot never saw the current head. Treat path (2) as confirmed only when the comment body explicitly refers to the current changes.
 
 ### Bounded Retry Workflow
+
+This path is only for a **genuinely missing** review - no Copilot review (formal *or* issue comment) covers the current head SHA after polling. A review that covered the head but produced no comments is a clean pass, not a missing review; do not enter this retry path for it.
 
 If a review did not run on the current head, retry:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,26 +1,61 @@
 # GitHub Copilot Instructions for LanguageTags
 
-The **canonical guide is [AGENTS.md](../AGENTS.md)** at the repo root - read it first. It covers branching, PR review etiquette, workflow YAML conventions, and the release pipeline.
-
-This file is intentionally focused: the GitHub Copilot Review Runbook (provider-specific mechanics behind the review-loop contract defined in AGENTS.md), followed by the LanguageTags-specific code conventions and public-API contract notes that VS Code's AI generators pick up directly from this path.
+The **canonical guide is [AGENTS.md](../AGENTS.md)** at the repo root - read it first, including the [PR Review Etiquette](../AGENTS.md#pr-review-etiquette) review-loop contract this file's runbook implements. This file is intentionally narrow: commit/PR-title conventions (summarized inline so VS Code's commit-message and PR-title generators have them) plus the GitHub Copilot Review Runbook.
 
 For C# style rules, see [`CODESTYLE.md`](../CODESTYLE.md) at the repo root. Do not duplicate those rules here.
 
+## Commit Messages and Pull Request Titles
+
+Summarized for VS Code's generators; the full rules, rationale, and examples are in [AGENTS.md "Pull Request Title and Commit Message Conventions"](../AGENTS.md#pull-request-title-and-commit-message-conventions).
+
+- Imperative subject, <= 72 characters, no trailing period; optional blank-line-separated body for the non-obvious *why*.
+- US English, title case with lowercase short bind words; no vague titles, no `Co-Authored-By:` unless asked, no release-bump magnitude (NBGV handles versioning). Dependabot's `Bump X from Y to Z` titles are fine.
+- develop PRs squash-merge (`gh pr merge --squash`), main PRs merge-commit (`--merge`); a mismatched flag is rejected by branch protection.
+
 ## GitHub Copilot Review Runbook
 
-Use this section for provider-specific mechanics. The expected review loop *contract* (request review on every push, verify head-SHA coverage, triage findings, reply + resolve, escalate when stuck) is defined in [AGENTS.md → PR Review Etiquette](../AGENTS.md#pr-review-etiquette). This section only describes how to make GitHub Copilot reliably execute it.
+> This runbook implements the [AGENTS.md "PR Review Etiquette"](../AGENTS.md#pr-review-etiquette) review-loop contract for GitHub Copilot. Without it in-repo, an agent has no pointer to the reliable Copilot mechanics and falls back to known-broken paths (the no-op `POST /requested_reviewers`, the wrong bot-login filter). In the API snippets below, `<N>` is the PR number.
+
+Use this section for provider-specific mechanics. The expected review loop *contract* (request review on every push, verify head-SHA coverage, triage findings, reply + resolve, escalate when stuck) is defined in [AGENTS.md -> PR Review Etiquette](../AGENTS.md#pr-review-etiquette). This section only describes how to make GitHub Copilot reliably execute it.
 
 ### Triggering and Polling
 
-Auto-review on push is configured (via the branch ruleset's `copilot_code_review` rule with `review_on_push: true`) but fires inconsistently in practice - treat it as best-effort, not guaranteed. Request review explicitly through the GitHub PR UI (request `Copilot` as a reviewer) after every push.
+Auto-review on push is configured (via the branch ruleset's `copilot_code_review` rule with `review_on_push: true`) but fires inconsistently in practice - treat it as best-effort, not guaranteed. After every push, **re-request a review programmatically** via the GraphQL `requestReviews` mutation, passing the Copilot reviewer's bot node id in `botIds`. This drives the loop end-to-end without a UI hand-off.
+
+> **The reviewer login differs by API.** In **GraphQL** (`gh api graphql` and `gh pr view --json reviews`, which is GraphQL-backed) the `Bot.login` is `copilot-pull-request-reviewer` - **no `[bot]` suffix**. In the **REST** API (`gh api repos/.../issues|pulls/...`) the same account's `user.login` is `copilot-pull-request-reviewer[bot]` - **with** the suffix. Each query below uses the correct form for its API; match the API, not a single spelling, when adapting them.
+
+```sh
+# 1. PR node id + the Copilot reviewer's bot node id (read from any existing
+#    Copilot review; the reviewer login is `copilot-pull-request-reviewer`).
+PR_NODE=$(gh pr view <N> --json id --jq '.id')
+BOT_ID=$(gh api graphql -f query='
+{
+  repository(owner: "ptr727", name: "LanguageTags") {
+    pullRequest(number: <N>) {
+      reviews(first: 50) { nodes { author { __typename login ... on Bot { id } } } }
+    }
+  }
+}' --jq '[.data.repository.pullRequest.reviews.nodes[]
+          | select(.author.login == "copilot-pull-request-reviewer")
+          | .author.id] | first')
+
+# 2. Re-request a Copilot review on the current head.
+gh api graphql -f query='
+mutation($pr: ID!, $bot: ID!) {
+  requestReviews(input: { pullRequestId: $pr, botIds: [$bot], union: true }) {
+    pullRequest { id }
+  }
+}' -F pr="$PR_NODE" -F bot="$BOT_ID"
+```
+
+The bot node id is read from an existing Copilot review, so step 1 needs at least one prior review on the PR - the auto-review-on-open normally supplies the first one. If no Copilot review exists yet and auto-review didn't fire, request `Copilot` once through the GitHub PR UI to seed it, then use the mutation for every subsequent re-request.
 
 **Do NOT post `@Copilot review` as a PR comment.** That comment triggers the Copilot *coding agent* (`copilot-swe-agent[bot]`), which makes code changes rather than posting a review.
 
-Known non-working request paths (don't rely on them):
+Known non-working request paths (don't rely on them - use the `requestReviews` mutation above instead):
 
 - `POST /requested_reviewers` with `reviewers=[Copilot]` can return 200 but no-op.
 - `copilot-pull-request-reviewer` as a requested reviewer slug returns 422.
-- GraphQL `requestReviews` rejects Copilot's bot node.
 
 ### Verify Review Covered Current Head
 
@@ -34,9 +69,10 @@ gh pr view <N> --json reviews --jq \
   '.reviews[] | select(.author.login=="copilot-pull-request-reviewer") | .commit.oid' \
   | grep -q "$PR_HEAD" && echo "covered via formal review"
 
-# 2. Issue comment - show the most recent Copilot comment for manual confirmation.
+# 2. Issue comment - show the most recent Copilot comment for manual
+#    confirmation. This is the REST API, so the login carries the `[bot]` suffix.
 gh api repos/ptr727/LanguageTags/issues/<N>/comments --jq \
-  '[.[] | select(.user.login=="copilot-pull-request-reviewer")] | last | {created_at, body: .body[:200]}'
+  '[.[] | select(.user.login=="copilot-pull-request-reviewer[bot]")] | last | {created_at, body: .body[:200]}'
 ```
 
 Coverage is confirmed when (1) exits 0. For issue comments (path 2), body content is the only reliable signal - `created_at` is not: `git log -1 --format=%cI` is the **commit** timestamp, not the push timestamp, so amended or rebased commits can have an earlier timestamp and an older Copilot comment could satisfy a time check even though Copilot never saw the current head. Treat path (2) as confirmed only when the comment body explicitly refers to the current changes.
@@ -46,7 +82,7 @@ Coverage is confirmed when (1) exits 0. For issue comments (path 2), body conten
 If a review did not run on the current head, retry:
 
 1. Wait briefly and check head-SHA coverage (see above).
-1. Request review again via the GitHub PR UI.
+1. Re-request the review via the `requestReviews` mutation (see "Triggering and Polling"); fall back to the GitHub PR UI only if the mutation no-ops.
 1. Retry up to two more times (three total).
 1. If still missing, mark review as blocked and escalate to the user/maintainer with what was attempted.
 
@@ -101,435 +137,6 @@ Reply-body conventions:
 
 After the final push, sweep-resolve stale older threads for removed code paths.
 
----
+## When in Doubt
 
-## Versioning
-
-`develop` leads `main` by a minor. After a `develop -> main` release lands and main's publish completes, bump the minor in [version.json](../version.json) on `develop` via an isolated `bump-version-X.Y` PR, so develop's NBGV prereleases sort above main's last stable. A `develop -> main` promotion that carries only maintenance (dependency/codegen bumps, CI/doc fixes, template re-syncs) holds main's version instead - `git checkout main -- version.json` on the promotion branch. See [AGENTS.md "Release Model"](../AGENTS.md#release-model).
-
-## Project Overview
-
-**LanguageTags** is a C# .NET library for handling ISO 639-2, ISO 639-3, and RFC 5646 / BCP 47 language tags. The project serves two primary purposes:
-
-1. **Data Publishing**: Provides ISO 639-2, ISO 639-3, and RFC 5646 language tag records in JSON and C# formats
-2. **Tag Processing**: Implements IETF BCP 47 language tag construction and parsing per RFC 5646 semantic rules
-
-**Current Version**: 1.2 (supports .NET 10.0, AOT compatible)
-
-**Important Note**: The implemented language tag parsing and normalization logic may be incomplete or inaccurate per RFC 5646. Always verify results for your specific use case
-
-## Solution Structure
-
-### Projects
-
-- **LanguageTags** (`LanguageTags/LanguageTags.csproj`)
-  - Core library project
-  - NuGet package: `ptr727.LanguageTags`
-  - Contains language tag data models, parser, builder, and lookup functionality
-  - Target framework: .NET 10.0
-  - C# language version: 14.0
-
-- **LanguageTagsCreate** (`LanguageTagsCreate/LanguageTagsCreate.csproj`)
-  - CLI utility for downloading and generating language data
-  - Downloads data from official sources (Library of Congress, SIL, IANA)
-  - Converts to JSON and generates C# code files
-  - Target framework: .NET 10.0
-
-- **LanguageTagsTests** (`LanguageTagsTests/LanguageTagsTests.csproj`)
-  - xUnit test suite with comprehensive coverage
-  - Uses AwesomeAssertions for test assertions
-  - Target framework: .NET 10.0
-
-### Key Directories
-
-- **LanguageData/**
-  - Contains downloaded language data files
-  - JSON converted data files
-  - Refreshed by daily codegen PRs; published with the weekly release
-
-- **.github/workflows/**
-  - `run-periodic-codegen-pull-request.yml`: Daily scheduled job that opens codegen PRs to update language data
-  - `publish-release.yml`: Sole publisher - weekly scheduled (Mon 02:00 UTC) + manual dispatch full build/publish of both branches; pushes only publish when `PUBLISH_ON_MERGE` is set (two-phase model)
-  - `test-pull-request.yml`: PR smoke test - unit tests + a reduced, never-published library build gated by `dorny/paths-filter`
-  - `merge-bot-pull-request.yml`: Automated PR merge workflow
-  - `build-release-task.yml`, `build-nugetlibrary-task.yml`: Build tasks
-  - `get-version-task.yml`, `build-datebadge-task.yml`: Version and badge generation
-
-### Project Configuration
-
-- **Directory.Build.props**: Common MSBuild properties shared across all projects
-  (`TargetFramework`, `Nullable`, `ImplicitUsings`, `AnalysisLevel`, `AnalysisMode`,
-  `EnableNETAnalyzers`, `ArtifactsPath`, `IsPackable`, `ManagePackageVersionsCentrally`)
-  live here at the solution root. Only add a property to a `.csproj` when it is
-  specific to that project or requires an explicit override of the shared default.
-
-- **Directory.Packages.props**: All NuGet package versions are centralised here via
-  `PackageVersion` items. Individual `.csproj` files use `PackageReference Include="..."`
-  with no `Version` attribute. Asset metadata (`PrivateAssets`, `IncludeAssets`) stays
-  in the `.csproj` `PackageReference` element. Use `VersionOverride` only when a project
-  genuinely requires a different version from the central default.
-
-## Core Components
-
-### LanguageTag Class (LanguageTag.cs)
-
-The main public API for working with language tags:
-
-**Static Factory Methods:**
-
-- `Parse(string tag)`: Parse a language tag string, returns null on failure
-- `TryParse(string tag, out LanguageTag? result)`: Safe parsing with out parameter
-- `ParseOrDefault(string tag, LanguageTag? defaultTag = null)`: Parse with fallback to "und"
-- `ParseAndNormalize(string tag)`: Parse and normalize in one step
-- `CreateBuilder()`: Create a fluent builder instance
-- `FromLanguage(string language)`: Factory for simple language tags
-- `FromLanguageRegion(string language, string region)`: Factory for language+region tags
-- `FromLanguageScriptRegion(string language, string script, string region)`: Factory for full tags
-
-**Properties:**
-
-- `Language`: Primary language subtag (internal set)
-- `ExtendedLanguage`: Extended language subtag (internal set)
-- `Script`: Script subtag (internal set)
-- `Region`: Region subtag (internal set)
-- `Variants`: ImmutableArray of variant subtags
-- `Extensions`: ImmutableArray of ExtensionTag objects
-- `PrivateUse`: PrivateUseTag object
-- `IsValid`: Property to check if tag is valid
-
-**Instance Methods:**
-
-- `Validate()`: Verify structural correctness
-- `Normalize()`: Return normalized copy of tag (does not validate)
-- `ToString()`: String representation
-- `Equals()`: Equality comparison (case-insensitive)
-- `GetHashCode()`: Hash code for collections
-- Operators: `==`, `!=`
-
-**Design Characteristics:**
-
-- Implements `IEquatable<LanguageTag>`
-- Constructors are internal, use factory methods or builder
-- Properties use internal setters to maintain immutability for public API
-- Collections exposed as ImmutableArray for thread safety
-
-### LanguageTagBuilder Class (LanguageTagBuilder.cs)
-
-Fluent builder for constructing language tags:
-
-**Methods:**
-
-- `Language(string value)`: Set primary language
-- `ExtendedLanguage(string value)`: Set extended language
-- `Script(string value)`: Set script
-- `Region(string value)`: Set region
-- `VariantAdd(string value)`: Add a variant
-- `VariantAddRange(IEnumerable<string> values)`: Add multiple variants
-- `ExtensionAdd(char prefix, IEnumerable<string> values)`: Add extension with prefix and values
-- `PrivateUseAdd(string value)`: Add private use tag
-- `PrivateUseAddRange(IEnumerable<string> values)`: Add multiple private use tags
-- `Build()`: Return constructed tag (no validation)
-- `Normalize()`: Return normalized tag (no validation)
-
-### LanguageTagParser Class (LanguageTagParser.cs)
-
-**Internal implementation** - Not exposed in public API. Use `LanguageTag.Parse()` instead.
-
-- Parses language tags according to RFC 5646 Section 2.1
-- Handles grandfathered tags and converts them to current forms
-- Normalizes tag casing according to RFC conventions:
-  - Language: lowercase
-  - Extended language: lowercase
-  - Script: Title case
-  - Region: UPPERCASE
-  - Variants: lowercase
-  - Extensions: lowercase
-  - Private use: lowercase
-
-### LanguageLookup Class (LanguageLookup.cs)
-
-Provides language code conversion and matching:
-
-**Properties:**
-
-- `Undetermined`: Constant for "und" (undetermined language)
-- `Overrides`: User-defined (IETF, ISO) mapping pairs
-
-**Methods:**
-
-- `GetIetfFromIso(string languageTag)`: Convert ISO to IETF format
-- `GetIsoFromIetf(string languageTag)`: Convert IETF to ISO format
-- `IsMatch(string prefix, string languageTag)`: Prefix matching for content selection
-
-### LogOptions Class (LogOptions.cs)
-
-Static class for configuring global logging for the entire library:
-
-**Properties:**
-
-- `LoggerFactory`: Gets or sets the global logger factory for creating category loggers
-
-**Methods:**
-
-- `SetFactory(ILoggerFactory loggerFactory)`: Configure the library to use a logger factory
-- `TrySetFactory(ILoggerFactory loggerFactory)`: Set factory only if none is configured
-
-**Logger Resolution Priority:**
-
-1. `LoggerFactory` property (when not `NullLoggerFactory`)
-2. `NullLogger.Instance` (default fallback)
-
-**Important Notes:**
-
-- Loggers are created and cached at time of use by each class instance
-- Changes to `LoggerFactory` after a logger is created do not affect existing cached loggers
-- Only new logger requests use updated configuration
-
-### Data Models
-
-#### Iso6392Data.cs
-
-- ISO 639-2 language codes (3-letter bibliographic/terminologic codes)
-- **Public Methods:**
-  - `Create()`: Load embedded data
-  - `FromDataAsync(string fileName)`: Load from file
-  - `FromJsonAsync(string fileName)`: Load from JSON
-  - `Find(string? languageTag, bool includeDescription)`: Find record by tag
-- **Internal Methods:** `SaveJsonAsync(string fileName)`, `SaveCodeAsync(string fileName)`
-- **Record Properties:** `Part2B`, `Part2T`, `Part1`, `RefName`
-
-#### Iso6393Data.cs
-
-- ISO 639-3 language codes (comprehensive language codes)
-- **Public Methods:**
-  - `Create()`: Load embedded data
-  - `FromDataAsync(string fileName)`: Load from file
-  - `FromJsonAsync(string fileName)`: Load from JSON
-  - `Find(string? languageTag, bool includeDescription)`: Find record by tag
-- **Internal Methods:** `SaveJsonAsync(string fileName)`, `SaveCodeAsync(string fileName)`
-- **Record Properties:** `Id`, `Part2B`, `Part2T`, `Part1`, `Scope`, `LanguageType`, `RefName`, `Comment`
-
-#### Rfc5646Data.cs
-
-- RFC 5646 / BCP 47 language subtag registry
-- **Public Methods:**
-  - `Create()`: Load embedded data
-  - `FromDataAsync(string fileName)`: Load from file
-  - `FromJsonAsync(string fileName)`: Load from JSON
-  - `Find(string? languageTag, bool includeDescription)`: Find record by tag
-- **Properties:** `FileDate`, `RecordList`
-- **Internal Methods:** `SaveJsonAsync(string fileName)`, `SaveCodeAsync(string fileName)`
-- **Record Properties:** `Type`, `Tag`, `SubTag`, `Description` (ImmutableArray), `Added`, `SuppressScript`, `Scope`, `MacroLanguage`, `Deprecated`, `Comments` (ImmutableArray), `Prefix` (ImmutableArray), `PreferredValue`, `TagValue`
-- **Enums:**
-  - `RecordType`: None, Language, ExtLanguage, Script, Variant, Grandfathered, Region, Redundant
-  - `RecordScope`: None, MacroLanguage, Collection, Special, PrivateUse
-
-#### Supporting Classes
-
-**ExtensionTag (sealed record):**
-
-- `Prefix`: Single-character extension prefix (char)
-- `Tags`: ImmutableArray of extension values
-- `ToString()`: Format as "prefix-tag1-tag2"
-- `Normalize()`: Returns normalized copy with sorted, lowercase tags
-- `Equals()`: Case-insensitive equality comparison
-
-**PrivateUseTag (sealed record):**
-
-- `Prefix`: Constant 'x'
-- `Tags`: ImmutableArray of private use values
-- `ToString()`: Format as "x-tag1-tag2"
-- `Normalize()`: Returns normalized copy with sorted, lowercase tags
-- `Equals()`: Case-insensitive equality comparison
-
-### Language Tag Structure
-
-Per RFC 5646, language tags follow this format:
-
-```text
-[Language]-[Extended language]-[Script]-[Region]-[Variant]-[Extension]-[Private Use]
-```
-
-Examples:
-
-- `zh`: Simple language tag
-- `zh-yue-hk`: Language with extended language and region
-- `en-latn-gb-boont-r-extended-sequence-x-private`: Full tag with all components
-
-### Data Updates
-
-- Language data is refreshed by daily codegen PRs and shipped with the weekly release (GitHub Actions)
-- The `LanguageTagsCreate` tool downloads data from:
-  - ISO 639-2: Library of Congress
-  - ISO 639-3: SIL International
-  - RFC 5646: IANA Language Subtag Registry
-- Generated C# files (`*DataGen.cs`) are committed to the repository
-- Data files are in `LanguageData/` directory
-
-## API Design Patterns
-
-### Factory Pattern
-
-Use static factory methods instead of public constructors:
-
-```csharp
-// Good
-LanguageTag tag = LanguageTag.Parse("en-US");
-LanguageTag tag = LanguageTag.FromLanguage("en");
-
-// Avoid - constructors are internal
-// var tag = new LanguageTag(); // Not accessible
-```
-
-### Builder Pattern
-
-Use fluent builder for complex tag construction:
-
-```csharp
-LanguageTag tag = LanguageTag.CreateBuilder()
-    .Language("en")
-    .Region("US")
-    .Build();
-```
-
-### Immutability Pattern
-
-- All properties are immutable after construction
-- Use `Normalize()` to get modified copies
-- Collections are exposed as `ImmutableArray<T>`
-
-### Safe Parsing
-
-Always use safe parsing patterns:
-
-```csharp
-// TryParse pattern
-if (LanguageTag.TryParse(input, out LanguageTag? tag))
-{
-    // Use tag
-}
-
-// ParseOrDefault pattern
-LanguageTag tag = LanguageTag.ParseOrDefault(input); // Falls back to "und"
-```
-
-## References and Standards
-
-- **RFC 5646**: Tags for Identifying Languages
-- **BCP 47**: Best Current Practice for Language Tags
-- **ISO 639-2**: 3-letter language codes
-- **ISO 639-3**: Comprehensive language codes
-- **ISO 15924**: Script codes
-- **ISO 3166-1**: Country codes
-- **UN M.49**: Geographic region codes
-- **IANA Language Subtag Registry**: Authoritative registry of subtags
-
-## Important Implementation Notes
-
-- The implemented language tag parsing and normalization logic may be incomplete or inaccurate
-- Grandfathered tags are automatically converted to their preferred values during parsing
-- All tag comparisons are case-insensitive per RFC 5646
-- Private use tags start with 'x-' prefix
-- Extensions use single-character prefixes (except 'x' which is reserved for private use)
-- `LanguageTagParser` is internal; all parsing is done through `LanguageTag` static methods
-
-## Recent API Changes
-
-### Changed (Breaking)
-
-- `LanguageTagParser` is now internal (use `LanguageTag.Parse()` instead)
-- Properties changed from `IList<string>` to `ImmutableArray<string>`:
-  - `VariantList` → `Variants`
-  - `ExtensionList` → `Extensions`
-  - `TagList` → `Tags`
-- Data file APIs are async-only and use static creators: `FromDataAsync()`/`FromJsonAsync()`
-- Logging configuration now uses `ILoggerFactory` only; `ILogger` support was removed from `LogOptions`
-- Tag construction requires use of factory methods or builder (constructors are internal)
-
-### Added (Non-Breaking)
-
-- `LanguageTag.ParseOrDefault()`: Safe parsing with fallback
-- `LanguageTag.ParseAndNormalize()`: Combined parse and normalize
-- `LanguageTag.IsValid`: Property for validation
-- `LanguageTag.FromLanguage()`, `FromLanguageRegion()`, `FromLanguageScriptRegion()`: Factory methods
-- `IEquatable<LanguageTag>` implementation with operators
-- `LogOptions` static class for global logging configuration with `ILoggerFactory`
-- `ExtensionTag` and `PrivateUseTag` are now sealed records with `Normalize()` and case-insensitive `Equals()` methods
-- Comprehensive XML documentation for all public APIs
-
-## Future Improvements
-
-Consider these areas for enhancement:
-
-- Use a BNF parser or parser generator (ANTLR4, Eto.Parse, etc.) instead of hand-parsing
-- Implement comprehensive subtag content validation against registry data
-- Add more language lookup and validation features
-- Improve error messages and diagnostics
-
-## Contributing
-
-- Follow the authoritative coding standards and tooling in `CODESTYLE.md` and `.editorconfig`
-- Add tests for new public behavior and keep API documentation complete
-- Use factory methods or builders for tag creation; avoid public constructors
-
-## Common Patterns
-
-### Creating Tags
-
-```csharp
-// Simple parsing
-LanguageTag? tag = LanguageTag.Parse("en-US");
-
-// Safe parsing
-if (LanguageTag.TryParse("en-US", out LanguageTag? tag))
-{
-    Console.WriteLine(tag.ToString());
-}
-
-// Parse with default
-LanguageTag tag = LanguageTag.ParseOrDefault(input); // "und" if invalid
-
-// Factory methods
-LanguageTag tag = LanguageTag.FromLanguage("en");
-LanguageTag tag = LanguageTag.FromLanguageRegion("en", "US");
-
-// Builder
-LanguageTag tag = LanguageTag.CreateBuilder()
-    .Language("en")
-    .Region("US")
-    .Build();
-```
-
-### Normalizing Tags
-
-```csharp
-// Parse and normalize separately
-LanguageTag? tag = LanguageTag.Parse("en-latn-us");
-LanguageTag? normalized = tag?.Normalize(); // "en-US"
-
-// Parse and normalize in one step
-LanguageTag? tag = LanguageTag.ParseAndNormalize("en-latn-us"); // "en-US"
-```
-
-### Accessing Tag Components
-
-```csharp
-LanguageTag tag = LanguageTag.Parse("en-latn-gb-boont-r-extended-x-private")!;
-
-string language = tag.Language; // "en"
-string script = tag.Script; // "latn"
-string region = tag.Region; // "gb"
-ImmutableArray<string> variants = tag.Variants; // ["boont"]
-ImmutableArray<ExtensionTag> extensions = tag.Extensions; // [{ Prefix='r', Tags=["extended"] }]
-PrivateUseTag privateUse = tag.PrivateUse; // { Tags=["private"] }
-```
-
-### Comparing Tags
-
-```csharp
-LanguageTag? tag1 = LanguageTag.Parse("en-US");
-LanguageTag? tag2 = LanguageTag.Parse("en-us");
-
-bool equal = tag1 == tag2; // true (case-insensitive)
-bool equal = tag1.Equals(tag2); // true
-int hash = tag1.GetHashCode(); // Same as tag2.GetHashCode()
+Read [AGENTS.md](../AGENTS.md) for this repo's conventions; [`CODESTYLE.md`](../CODESTYLE.md) is authoritative for C# style. Don't restate any of these files' rules in commit bodies or PR descriptions - keep those focused on the change itself. If you find a discrepancy that should be fixed in the template itself (this file or AGENTS.md is out of date, a rule is missing, something bit this repo and would bite the next derived repo), open an issue upstream in [`ptr727/ProjectTemplate`](https://github.com/ptr727/ProjectTemplate) rather than only fixing it locally - see [AGENTS.md "Staying in Sync with the Template"](../AGENTS.md#staying-in-sync-with-the-template).

--- a/.github/workflows/build-nugetlibrary-task.yml
+++ b/.github/workflows/build-nugetlibrary-task.yml
@@ -7,7 +7,7 @@ env:
 on:
   workflow_call:
     inputs:
-      # Input to control whether to push the NuGet library to NuGet.org
+      # Whether to push the NuGet library to NuGet.org.
       push:
         required: false
         type: boolean
@@ -17,9 +17,8 @@ on:
         required: false
         type: string
         default: ''
-      # Logical branch driving build configuration (`main` => Release, else
-      # Debug). Required (no `github.ref_name` fallback, which would mislabel
-      # the develop leg of the publisher's matrix); the orchestrator passes it.
+      # Logical branch driving build configuration (`main` => Release, else Debug). Required (no fallback) so the
+      # develop leg of the publisher's matrix isn't mislabeled.
       branch:
         required: true
         type: string
@@ -91,3 +90,5 @@ jobs:
         with:
           name: nugetlibrary-build-${{ inputs.branch }}
           path: ${{ runner.temp }}/${{ env.PROJECT_ARTIFACT }}
+          # Intermediate artifact consumed by build-release-task in the same run.
+          retention-days: 1

--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -18,24 +18,19 @@ on:
         required: false
         type: string
         default: ''
-      # Logical branch driving config / tags / prerelease for every target.
-      # Required (no `github.ref_name` fallback): the publisher builds both
-      # `main` and `develop` from one run whose `github.ref_name` is `main`,
-      # so a silent fallback would mislabel the develop leg. Every caller
-      # passes it explicitly; a missing value should fail loudly.
+      # Logical branch driving config / tags / prerelease for every target. Required (no fallback) because the
+      # publisher builds both `main` and `develop` in one run, so a silent fallback would mislabel the develop leg.
       branch:
         required: true
         type: string
-      # Smoke mode: reduced, never-published build for fast PR feedback.
-      # Forwarded to every target; also hard-disables every push below so a
-      # smoke run can never publish regardless of the publish flags.
+      # Smoke mode: reduced, never-published build for fast PR feedback. Forwarded to every target and hard-disables
+      # every push below, so a smoke run can never publish regardless of the publish flags.
       smoke:
         required: false
         type: boolean
         default: false
-      # Per-target presence gate. Default true (build everything). A PR smoke
-      # run sets this from the paths-filter so the library only builds when it
-      # actually changed.
+      # Per-target presence gate. Default true (build everything); a PR smoke run sets it from the paths-filter
+      # so the library only builds when it changed.
       enable_nuget:
         required: false
         type: boolean
@@ -57,29 +52,23 @@ jobs:
     uses: ./.github/workflows/build-nugetlibrary-task.yml
     secrets: inherit
     with:
-      # Pin to the exact commit get-version resolved (immutable), not the
-      # possibly-moving branch ref: the publisher passes a branch name, and a
-      # commit landing mid-run could otherwise build artifacts from a different
-      # commit than the one the release tag (also GitCommitId) points at.
+      # Pin to the resolved commit so the artifacts match the release tag even if the branch advances mid-run.
       ref: ${{ needs.get-version.outputs.GitCommitId }}
       branch: ${{ inputs.branch }}
-      # Conditional push to NuGet.org — never on a smoke build.
+      # Push to NuGet.org, never on a smoke build.
       push: ${{ inputs.nuget && !inputs.smoke }}
 
   github-release:
     name: Publish GitHub release job
-    # `&& !inputs.smoke` enforces the "smoke never publishes" guarantee at the
-    # job level too (matching the `&& !inputs.smoke` push gate above), so a
-    # smoke caller that also set `github: true` still can't create a release.
+    # `!inputs.smoke` enforces "smoke never publishes" at the job level, so a smoke caller that also set
+    # `github: true` still can't create a release.
     if: ${{ inputs.github && !inputs.smoke }}
     runs-on: ubuntu-latest
     needs: [get-version, build-nugetlibrary]
 
     steps:
 
-      # Check out the exact built commit (NBGV `GitCommitId`), not the
-      # possibly-moving `inputs.ref` branch, so the uploaded release files
-      # match the tag even if the branch advances mid-run.
+      # Check out the exact built commit so the uploaded release files match the tag even if the branch advances mid-run.
       - name: Checkout code step
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -91,12 +80,8 @@ jobs:
           artifact-ids: ${{ needs.build-nugetlibrary.outputs.artifact-id }}
           path: ./Publish
 
-      # The weekly publisher re-runs even when a branch has no new commits, so
-      # NBGV can produce a SemVer2 that was already released. GitHub release
-      # creation has no built-in skip-duplicate (unlike NuGet's
-      # `--skip-duplicate`), and re-publishing an unchanged version is exactly
-      # the churn the two-phase model avoids — so skip the release step when a
-      # release for this tag already exists.
+      # The weekly publisher re-runs even with no new commits, so the version may already be released. Skip the release
+      # step when a release for this tag already exists to avoid a no-op republish.
       - name: Check for existing release step
         id: release-exists
         env:
@@ -115,17 +100,9 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # `target_commitish` MUST be set explicitly: softprops doesn't pass a
-      # default through, and GitHub's REST API then defaults the new tag to
-      # the repository's default branch (main). We pin it to NBGV's
-      # `GitCommitId` — the exact commit the version was computed from. This
-      # avoids two bugs: `github.sha` would be wrong (the publisher's branch
-      # matrix builds `develop` from a run whose `github.sha` is main's tip),
-      # and `inputs.branch` would be a moving ref (a commit landing mid-run
-      # could tag the release on a newer commit than the one that was built).
-      # Skip the no-op weekly republish when the tag already exists, but always
-      # allow a manual `workflow_dispatch` through so it can repair/refresh a
-      # partially-created release for the same tag.
+      # `target_commitish` must be set explicitly: otherwise GitHub's REST API tags the release on the default branch.
+      # Pin it to `GitCommitId` so the tag is on the exact built commit, consistent with the SemVer2 tag and artifacts.
+      # Skip when the release already exists, but always let a manual `workflow_dispatch` through to refresh it.
       - name: Create GitHub release step
         if: ${{ steps.release-exists.outputs.exists == 'false' || github.event_name == 'workflow_dispatch' }}
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0

--- a/.github/workflows/get-version-task.yml
+++ b/.github/workflows/get-version-task.yml
@@ -3,11 +3,8 @@ name: Get version information task
 on:
   workflow_call:
     inputs:
-      # Git ref to check out and version. Empty string falls back to the
-      # caller's default checkout ref (`github.ref`), preserving the original
-      # behavior. The publisher passes an explicit branch so a scheduled run —
-      # which always reports `github.ref` as the default branch — can still
-      # compute NBGV versions for `develop` too.
+      # Git ref to check out and version. Empty falls back to the caller's default checkout ref (`github.ref`); the
+      # publisher passes an explicit branch so a scheduled run can still compute versions for `develop`.
       ref:
         required: false
         type: string
@@ -22,9 +19,7 @@ on:
         value: ${{ jobs.get-version.outputs.AssemblyFileVersion }}
       AssemblyInformationalVersion:
         value: ${{ jobs.get-version.outputs.AssemblyInformationalVersion }}
-      # Full SHA of the commit NBGV computed the version from. Used to pin the
-      # GitHub release tag and the built artifacts to the exact built commit
-      # (immutable), rather than a moving branch ref.
+      # Full SHA of the commit the version was computed from, used to pin the release tag to the exact built commit.
       GitCommitId:
         value: ${{ jobs.get-version.outputs.GitCommitId }}
 
@@ -53,10 +48,8 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
 
-      # nbgv is intentionally NOT SHA-pinned: the upstream tag stream lags
-      # `master` substantially and Dependabot's tag-tracking would propose
-      # a downgrade. Documented exception to the Workflow YAML Conventions
-      # action-pinning rule in AGENTS.md.
+      # nbgv is floated on @master: its tag stream lags master, so Dependabot tag-tracking would propose a downgrade.
+      # Revisit if dotnet/nbgv resumes regular tagged releases.
       - name: Run Nerdbank.GitVersioning tool step
         id: nbgv
         uses: dotnet/nbgv@master

--- a/.github/workflows/merge-bot-pull-request.yml
+++ b/.github/workflows/merge-bot-pull-request.yml
@@ -1,64 +1,20 @@
 name: Merge bot pull request action
 
-# Three-job model:
-#   1. `merge-dependabot` / `merge-codegen` run on `opened` and `reopened`
-#      events only. They enable auto-merge via `gh pr merge --auto` once
-#      per PR. Restricting to open/reopen (skipping `synchronize`) is what
-#      makes step 3 below stick — if these jobs re-ran on every
-#      `synchronize`, they'd undo a maintainer-triggered disable.
-#   2. The merge method (`--squash` vs `--merge`) is dispatched by a
-#      `case` statement on `pull_request.base.ref` so the form matches
-#      each branch's ruleset (develop = squash-only, main = merge-only,
-#      see AGENTS.md "Branching Model"). Both Dependabot and codegen
-#      open parallel PRs against both branches; Dependabot security
-#      updates always target `main` and flow through the same code path.
-#   3. `disable-auto-merge-on-maintainer-push` runs on `synchronize`
-#      events against bot-authored PRs when the event actor is NOT the
-#      same bot — i.e. a maintainer pushed commits to a bot PR. It
-#      calls `gh pr merge --disable-auto` so the maintainer's commits
-#      don't auto-merge along with the bot's content. The maintainer
-#      re-enables auto-merge manually (UI or `gh pr merge --auto`)
-#      when ready.
-#
-# Token strategy:
-#   Every job uses an App token (`actions/create-github-app-token`).
-#   The resulting push is committed by the App, which fires downstream
-#   workflows on develop and main. `GITHUB_TOKEN`-authored pushes are
-#   blocked from triggering further workflow runs by GitHub's recursion
-#   guard, which would silently skip `publish-release.yml` on the merge
-#   commit. The App-token path also removes the close/reopen dance
-#   previously used by codegen PRs created under `GITHUB_TOKEN` to nudge
-#   the auto-merge workflow. The disable job needs an App token too:
-#   even though the event actor is a maintainer, the workflow context
-#   on a Dependabot PR runs with Dependabot's restricted secrets
-#   regardless of actor, so plain `GITHUB_TOKEN` would be read-only.
+# The merge jobs enable auto-merge once per PR on opened/reopened; the disable job turns it off when a
+# maintainer pushes to a bot branch. Merge method is dispatched by base branch (develop = squash, main = merge).
+# All jobs use an App token so the merge commit fires downstream workflows (GITHUB_TOKEN pushes don't, due to
+# GitHub's recursion guard) and so the disable job has write access on Dependabot PRs, which otherwise run with
+# read-only restricted secrets regardless of who triggered the event.
 
-# `pull_request_target` rather than `pull_request`: this workflow holds
-# the App private key in env (`GH_TOKEN`) and runs actions
-# (`create-github-app-token`, `fetch-metadata`) that consume it. Under
-# `pull_request` the workflow definition AND the action SHAs come from
-# the PR head — meaning a Dependabot bump of `actions/create-github-app-token`
-# (or any other action used here) would execute the new, unreviewed SHA
-# with full access to the App key. `pull_request_target` runs from the
-# base-branch workflow definition, so action-SHA changes only take effect
-# *after* they're merged. Safe because this workflow never checks out PR
-# code — it only calls `gh pr merge` against the PR by URL, so the usual
-# `pull_request_target` warning about untrusted PR code doesn't apply.
+# `pull_request_target` (not `pull_request`): jobs hold the App private key, so action SHAs must come from the
+# base-branch definition, not the PR head. Safe because this workflow never checks out PR code - it only runs
+# `gh pr merge` against the PR by URL.
 on:
   pull_request_target:
     types: [opened, reopened, synchronize]
 
-# `cancel-in-progress: false` is load-bearing. The three-job model
-# (enable on opened/reopened, disable on maintainer-triggered
-# synchronize) relies on those events running to completion in arrival
-# order. With cancel-in-progress: true, a fast follow-up synchronize
-# (e.g. a Dependabot rebase right after PR open) would cancel the
-# in-flight `opened` run before it reached `gh pr merge --auto`, and
-# the new synchronize run skips the enable jobs (opened/reopened
-# filter), leaving auto-merge never enabled. Queueing instead of
-# cancelling makes the final state deterministic: opened enables,
-# then any subsequent synchronize disables (if maintainer) or no-ops
-# (if bot).
+# `cancel-in-progress: false` is required so events process to completion in arrival order: a follow-up
+# synchronize must not cancel an in-flight `opened` run before it enables auto-merge.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
@@ -68,12 +24,7 @@ jobs:
   merge-dependabot:
     name: Merge dependabot pull request job
     runs-on: ubuntu-latest
-    # Restrict to Dependabot PRs that originate from this repository, not
-    # a fork. Only runs on `opened` / `reopened` events so the auto-merge
-    # enable happens once per PR; the `disable-auto-merge-on-maintainer-push`
-    # job below is what disables auto-merge when a maintainer pushes to a
-    # Dependabot branch. Skipping `synchronize` here is what keeps that
-    # disable sticky.
+    # Dependabot PRs from this repo (not forks). Only on opened/reopened so the disable job stays sticky.
     if: >-
       (github.event.action == 'opened' || github.event.action == 'reopened') &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
@@ -97,9 +48,7 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      # Skip semver-major NuGet bumps: majors can build cleanly but break
-      # runtime behavior, so they should land via human review. Other
-      # ecosystems' majors (github-actions) are usually safe and merge.
+      # Skip semver-major NuGet bumps so they land via human review; other ecosystems' majors auto-merge.
       - name: Merge pull request step
         if: >-
           (steps.metadata.outputs.package-ecosystem != 'nuget') ||
@@ -122,17 +71,8 @@ jobs:
   merge-codegen:
     name: Merge codegen pull request job
     runs-on: ubuntu-latest
-    # Restrict to codegen PRs that originate from the App in this
-    # repository. Codegen runs in a matrix over `main` and `develop`,
-    # so two head refs are valid: `codegen-main` (always targets `main`)
-    # and `codegen-develop` (always targets `develop`). The head/base
-    # pairing is enforced strictly so a misconfigured workflow can't,
-    # for example, sneak a `codegen-develop` branch into `main`.
-    # Only runs on `opened` / `reopened` events so the auto-merge enable
-    # happens once per PR; the `disable-auto-merge-on-maintainer-push`
-    # job below is what disables auto-merge when a maintainer pushes to a
-    # codegen branch. Skipping `synchronize` here is what keeps that
-    # disable sticky.
+    # Codegen PRs from this repo. Head/base pairing is enforced strictly (codegen-main->main,
+    # codegen-develop->develop). Only on opened/reopened so the disable job stays sticky.
     if: >-
       (github.event.action == 'opened' || github.event.action == 'reopened') &&
       github.event.pull_request.user.login == 'ptr727-codegen[bot]' &&
@@ -173,15 +113,8 @@ jobs:
   disable-auto-merge-on-maintainer-push:
     name: Disable auto-merge on maintainer push job
     runs-on: ubuntu-latest
-    # Fires on `synchronize` events against bot-authored PRs (Dependabot
-    # or codegen) when the event actor is NOT the same bot — i.e. a
-    # maintainer pushed commits to the bot's branch. Disables auto-merge
-    # so the maintainer's commits don't auto-merge along with the bot's
-    # content. The maintainer re-enables auto-merge manually when ready
-    # (UI button, or `gh pr merge --auto <PR>`).
-    #
-    # `gh pr merge --disable-auto` is idempotent — calling it on a PR
-    # that already has auto-merge disabled is a no-op.
+    # Fires when a maintainer pushes to a bot's branch (synchronize, actor != bot). Disables auto-merge so the
+    # maintainer's commits don't merge with the bot's; they re-enable it manually. The disable call is idempotent.
     if: >-
       github.event.action == 'synchronize' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
@@ -196,11 +129,7 @@ jobs:
     steps:
 
       - name: Generate GitHub App token step
-        # App token rather than GITHUB_TOKEN: on a Dependabot PR the
-        # workflow context runs with Dependabot's restricted secrets
-        # regardless of who triggered the event (GitHub gates by PR
-        # origin, not by event actor), and the restricted GITHUB_TOKEN
-        # is read-only. Same App token pattern as the other merge jobs.
+        # App token because a Dependabot PR's GITHUB_TOKEN is read-only regardless of who triggered the event.
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,36 +5,25 @@ on:
     branches: [ main, develop ]
   workflow_dispatch:
   schedule:
-    # Weekly full build/publish of both branches on Mondays at 02:00 UTC.
-    # This is the guaranteed publisher in the default two-phase model: routine
-    # merges only smoke-test, and this scheduled run republishes everything.
+    # Weekly full build/publish of both branches on Mondays at 02:00 UTC. Routine merges only smoke-test;
+    # this scheduled run republishes everything.
     - cron: '0 2 * * MON'
 
-# Real publishes (schedule, dispatch, or push when PUBLISH_ON_MERGE is set)
-# share a single GLOBAL, ref-independent group so they serialize: a scheduled
-# run and a manual dispatch both build BOTH branches regardless of the
-# triggering ref, so a ref-scoped group would let a scheduled run (ref=main)
-# and a manual dispatch (ref=develop) run concurrently and double-publish.
-# Non-publishing `push` runs (the two-phase default) get a unique per-run group
-# so they don't queue behind — or delay — a real publish; they only execute the
-# no-op `setup` job and skip everything else.
+# Real publishes (schedule, dispatch, or push with PUBLISH_ON_MERGE) share one global group so they serialize: they
+# build and create releases for both branches regardless of the triggering ref, so a ref-scoped group could let two
+# real publishes run concurrently and double-publish. Non-publishing push runs get a unique per-run group so they
+# don't queue behind a real publish; they only run the no-op setup job.
 concurrency:
   group: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || vars.PUBLISH_ON_MERGE == 'true') && github.workflow || format('{0}-noop-{1}', github.workflow, github.run_id) }}
-  # Documented exception to the standard `cancel-in-progress: true` (see
-  # AGENTS.md "Workflow YAML Conventions"): cancelling a publish mid-flight can
-  # leave a half-created GitHub release or a partially pushed NuGet package.
-  # Queue instead of cancel so each publish runs to completion.
+  # Queue instead of cancel: cancelling a publish mid-flight can leave a half-created GitHub release or a partially
+  # pushed NuGet package.
   cancel-in-progress: false
 
 jobs:
 
-  # Decide WHICH branches to publish and WHETHER to publish at all:
-  #   - push        -> publish only the pushed branch, and only when the
-  #                    `PUBLISH_ON_MERGE` repository variable is `true`
-  #                    (opt-in legacy continuous-release). Unset/false => the
-  #                    default two-phase model: merges don't publish.
-  #   - schedule    -> always publish BOTH branches (the weekly full build).
-  #   - dispatch    -> always publish BOTH branches (manual on-demand publish).
+  # Decide which branches to publish and whether to publish at all: push -> only the pushed branch, and only when the
+  # PUBLISH_ON_MERGE variable is true (default two-phase model: merges don't publish); schedule/dispatch -> both
+  # branches.
   setup:
     name: Resolve publish plan job
     runs-on: ubuntu-latest
@@ -45,8 +34,7 @@ jobs:
       - name: Compute publish plan step
         id: plan
         env:
-          # Repository variable (Settings -> Actions -> Variables). Unset reads
-          # as empty string, so the default is the two-phase model.
+          # Repository variable; unset reads as empty string, so the default is the two-phase model.
           PUBLISH_ON_MERGE: ${{ vars.PUBLISH_ON_MERGE }}
         run: |
           set -euo pipefail
@@ -69,10 +57,8 @@ jobs:
           echo "branches=$branches" >> "$GITHUB_OUTPUT"
           echo "publish=$publish" >> "$GITHUB_OUTPUT"
 
-  # Full build + publish for each planned branch. The branch matrix lets a
-  # single scheduled run publish both `main` (Release, non-prerelease) and
-  # `develop` (Debug, prerelease) — each leg checks out and versions its own
-  # branch via the threaded `ref`/`branch`.
+  # Full build + publish for each planned branch. The matrix lets one run publish both `main` (Release, non-prerelease)
+  # and `develop` (Debug, prerelease) - each leg checks out and versions its own branch via the threaded ref/branch.
   publish:
     name: Publish project release job
     needs: [setup]

--- a/.github/workflows/run-codegen-pull-request-task.yml
+++ b/.github/workflows/run-codegen-pull-request-task.yml
@@ -1,12 +1,7 @@
 name: Run codegen and pull request task
 
-# Runs codegen against `main` and `develop` in parallel via a matrix,
-# opens a PR against each base (`codegen-main` branch → main,
-# `codegen-develop` branch → develop). The merge-bot auto-merges
-# either PR independently. This keeps both branches current on
-# generated content without either branch falling behind the other
-# and without main → develop back-merges (see AGENTS.md
-# "Branching Model" for the forward-only develop invariant).
+# Runs codegen against `main` and `develop` in parallel via a matrix and opens a PR against each base
+# (codegen-main -> main, codegen-develop -> develop), which the merge-bot auto-merges independently.
 
 on:
   workflow_call:
@@ -26,8 +21,7 @@ jobs:
       contents: write
       pull-requests: write
     strategy:
-      # Each branch gets its own parallel codegen run + PR. If one
-      # branch's PR fails (CI, conflicts, etc.) the other is unaffected.
+      # Each branch gets its own parallel codegen run + PR; one branch's failure doesn't affect the other.
       fail-fast: false
       matrix:
         target:
@@ -39,10 +33,7 @@ jobs:
     steps:
 
       - name: Generate GitHub App token step
-        # The App-token-driven PR open fires `pull_request` workflow events
-        # directly. `GITHUB_TOKEN`-driven PR opens do not (GitHub's recursion
-        # guard), which previously required a close/reopen dance under a PAT
-        # to nudge the auto-merge workflow — that dance is gone.
+        # App token so the PR open fires `pull_request` workflow events (GITHUB_TOKEN opens don't).
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -78,7 +69,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         id: cpr
         with:
-          # App token: triggers pull_request workflow events directly, creates verified commits as the app
+          # App token: triggers pull_request workflow events and creates verified commits as the app.
           token: ${{ steps.app-token.outputs.token }}
           base: ${{ matrix.target.ref }}
           branch: ${{ matrix.target.branch }}

--- a/.github/workflows/run-periodic-codegen-pull-request.yml
+++ b/.github/workflows/run-periodic-codegen-pull-request.yml
@@ -3,22 +3,12 @@ name: Run daily codegen and pull request action
 on:
   workflow_dispatch:
   schedule:
-    # Run daily at 04:00 UTC. Staggered two hours after the weekly publish
-    # (`publish-release.yml`, Mondays 02:00) so the two don't start together
-    # on Mondays. Codegen merges are cheap in the default two-phase model
-    # (they only smoke-test, the weekly publish batches the actual release),
-    # so running daily keeps both branches' generated content fresh without
-    # triggering a build per merge.
+    # Daily at 04:00 UTC, staggered after the weekly publish so the two don't start together on Mondays.
     - cron: '0 4 * * *'
 
 concurrency:
-  # Constant (workflow-name only, no ref) rather than the standard
-  # ${{ github.workflow }}-${{ github.ref }} pattern: the reusable
-  # task this calls always writes to the fixed external branches
-  # `codegen-main` and `codegen-develop` regardless of triggering ref,
-  # so a workflow_dispatch from any non-default ref must NOT run
-  # concurrently with the scheduled (default-branch) run — both would
-  # race updating the same codegen branches and PRs.
+  # Workflow-only group (no `-${{ github.ref }}`): the task writes to the fixed `codegen-main`/`codegen-develop`
+  # branches regardless of triggering ref, so a dispatch and the scheduled run must not race on them.
   group: ${{ github.workflow }}
   cancel-in-progress: true
 

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -2,10 +2,7 @@ name: Test pull request action
 
 on:
   pull_request:
-    # The `branches:` filter under `pull_request` matches the PR's BASE
-    # branch. `codegen-main` and `codegen-develop` are head-only branches
-    # (the codegen workflow opens PRs *from* them into `main` / `develop`)
-    # so they're never bases — only the protected base branches go here.
+    # Matches the PR's base branch; `codegen-main`/`codegen-develop` are head-only, so only the protected bases go here.
     branches: [ main, develop ]
   workflow_dispatch:
 
@@ -15,21 +12,14 @@ concurrency:
 
 jobs:
 
-  # Detect whether a PR actually touches the library so we only smoke-build
-  # when it changed. Build-workflow files are intentionally NOT in the filter:
-  # a path filter can't tell a logic change in a build workflow from an action-
-  # version bump. A workflow-only change is therefore not smoke-built — the
-  # reusable workflows are exercised instead by the next run that uses them (a
-  # later code PR's smoke build, or the scheduled/publish run); lint workflow
-  # edits with `actionlint` locally before pushing (there is no CI lint job).
-  # On `workflow_dispatch` (no PR base to diff against) the target is forced on
-  # so a manual run is a full smoke build.
+  # Detect whether a PR touches the library so we smoke-build only when it changed.
+  # Build-workflow files are deliberately excluded - a path filter can't tell a logic
+  # change from an action-version bump - so workflow-only changes aren't smoke-built;
+  # lint them with `actionlint` locally. workflow_dispatch forces the build on.
   changes:
     name: Detect changed targets job
     runs-on: ubuntu-latest
-    # `dorny/paths-filter` lists the PR's changed files via the GitHub API
-    # (this job does not check out the tree), which needs `pull-requests: read`.
-    # The repo's default GITHUB_TOKEN is restricted, so grant it explicitly.
+    # dorny/paths-filter reads changed files via the API (no checkout), so grant pull-requests: read.
     permissions:
       contents: read
       pull-requests: read
@@ -51,8 +41,7 @@ jobs:
               - *shared
               - 'LanguageTags/**'
 
-  # Unit tests are cheap and validate the library, so they always run
-  # regardless of whether the smoke build is gated off.
+  # Unit tests are cheap and validate the library, so they always run regardless of the smoke-build gate.
   unit-test:
     name: Run unit tests job
     runs-on: ubuntu-latest
@@ -67,8 +56,7 @@ jobs:
       - name: Checkout code step
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # `dotnet husky run` is the repo's git-hook runner; it invokes the same
-      # CSharpier + dotnet format style checks the build conventions require.
+      # `dotnet husky run` runs the repo's git hooks: the CSharpier + dotnet format style checks.
       - name: Check code style step
         run: |
           set -euo pipefail
@@ -79,11 +67,8 @@ jobs:
       - name: Run unit tests step
         run: dotnet test
 
-  # Fast PR feedback: build the library in smoke mode (Debug for develop /
-  # Release for main, no publishing). Validates the PR's base-branch
-  # configuration by passing `branch: github.base_ref`. Skipped entirely when
-  # the library didn't change (e.g. a docs-only or workflow-only PR) — unit
-  # tests still run.
+  # Build the library in smoke mode (Debug for develop / Release for main, no publishing), in the PR base-branch
+  # configuration. Skipped when the library didn't change; unit tests still run.
   smoke-build:
     name: Smoke build changed targets job
     needs: [changes, unit-test]
@@ -95,20 +80,16 @@ jobs:
       # Do not publish anything from a PR.
       github: false
       nuget: false
-      # Check out the PR head by SHA (not head_ref): the head SHA is reachable
-      # in the base repo via refs/pull/N/head even for fork PRs, whereas the
-      # head_ref branch name does not exist in the base repo for forks and
-      # would fail checkout. Validate it in the base branch's configuration.
-      # `workflow_dispatch` has no pull_request payload, so fall back to the
-      # triggering ref.
+      # Check out the PR head by SHA: refs/pull/N/head is reachable in the base repo even for
+      # forks, unlike the head_ref branch name. workflow_dispatch falls back to the triggering ref.
       ref: ${{ github.event.pull_request.head.sha || github.ref_name }}
       branch: ${{ github.base_ref || github.ref_name }}
       enable_nuget: ${{ needs.changes.outputs.nuget == 'true' }}
 
-  # TODO: Workaround for GitHub Actions not supporting status checks on conditional jobs
+  # TODO: GitHub Actions does not support required status checks on conditional jobs.
   # https://github.com/orgs/community/discussions/12395#discussioncomment-12970019
-  # This job's name is bound to the branch ruleset as the required status check
-  # context — do NOT rename it (see AGENTS.md "Workflow YAML Conventions").
+  # This aggregator and its job name are verbatim orchestration: the name is the
+  # ruleset-bound required status-check context - do NOT rename it.
   check-workflow-status:
     name: Check pull request workflow status
     runs-on: ubuntu-latest
@@ -125,15 +106,12 @@ jobs:
               exit 1
             fi
           }
-          # The paths-filter job MUST succeed: if it failed we don't know
-          # whether the library changed, so a library-changing PR could merge
-          # with its smoke build silently skipped. Treat anything other than
-          # success as a block.
+          # The changes job MUST succeed - a paths-filter error must not let a
+          # library-changing PR merge with its smoke build silently skipped.
           if [[ "${{ needs.changes.result }}" != "success" ]]; then
             echo "Job 'changes' did not succeed (${{ needs.changes.result }}); refusing to pass."
             exit 1
           fi
-          # unit-test always runs; smoke-build may be legitimately skipped
-          # (library unchanged) — `skipped` passes, only failure/cancelled blocks.
+          # smoke-build may be legitimately skipped (library unchanged); only failure/cancelled blocks.
           exit_on_result "unit-test" "${{ needs.unit-test.result }}"
           exit_on_result "smoke-build" "${{ needs.smoke-build.result }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,12 +15,12 @@ This file is the canonical reference for cross-cutting AI-agent and workflow rul
 
 ## Branching Model
 
-- `develop` is the integration branch. Feature branches → `develop` is **squash-only**; develop is kept linear.
-- `develop` → `main` is **merge-commit only** (no squash, no rebase). Merge commits preserve develop's commit list as a real second-parent reference on main, which lets the release model attribute releases to the develop commits that produced them (relevant both for the weekly publish and the opt-in `PUBLISH_ON_MERGE` mode - see "Release Model" below). Branch protection enforces this: the develop ruleset allows only `squash`, the main ruleset allows only `merge`.
+- `develop` is the integration branch. Feature branches -> `develop` is **squash-only**; develop is kept linear.
+- `develop` -> `main` is **merge-commit only** (no squash, no rebase). Merge commits preserve develop's commit list as a real second-parent reference on main, which lets the release model attribute releases to the develop commits that produced them (relevant both for the weekly publish and the opt-in `PUBLISH_ON_MERGE` mode - see "Release Model" below). Branch protection enforces this: the develop ruleset allows only `squash`, the main ruleset allows only `merge`.
 - All commits on both branches must be cryptographically signed (SSH or GPG). Squash and merge commits created via the GitHub UI are signed by GitHub's web-flow key.
-- **`develop` is forward-only - no `main → develop` back-merges.** The develop ruleset's squash-only setting physically blocks merge commits on develop. Historical back-merge commits visible in `git log` predate this rule and must not be repeated.
+- **`develop` is forward-only - no `main -> develop` back-merges.** The develop ruleset's squash-only setting physically blocks merge commits on develop. Historical back-merge commits visible in `git log` predate this rule and must not be repeated.
 - **Both rulesets intentionally omit "Require branches to be up to date before merging" (`strict_required_status_checks_policy: false`), for two distinct reasons:**
-  - *Main* - the check is graph-based; it asks whether main's tip commit is reachable from develop, not whether the two branches have the same content. After any develop → main release, main's tip is a brand-new merge commit that develop's history doesn't contain. Forward-only develop never adds it (no back-merge of main into develop), so the check would fail on every subsequent release.
+  - *Main* - the check is graph-based; it asks whether main's tip commit is reachable from develop, not whether the two branches have the same content. After any develop -> main release, main's tip is a brand-new merge commit that develop's history doesn't contain. Forward-only develop never adds it (no back-merge of main into develop), so the check would fail on every subsequent release.
   - *Develop* - bot auto-merge incompatibility. When two bot PRs against develop land in the same minute (e.g. two grouped Dependabot PRs from the same daily run), the first to merge pushes the second into `mergeStateStatus: BEHIND`. GitHub's auto-merge will not fire while the strict flag is on, and nothing in the workflow set auto-updates a bot branch in that window - the merge-bot only *enables* auto-merge on `opened`/`reopened` (see [`merge-bot-pull-request.yml`](./.github/workflows/merge-bot-pull-request.yml)). Real file-level conflicts are still caught textually (`mergeable: CONFLICTING` blocks merge regardless); semantic-but-not-textual conflicts that combine cleanly are caught by the post-merge develop CI run rather than pre-merge. Do not reintroduce the strict flag on develop thinking it's hygiene - it breaks bot auto-merge.
 - **Bots (Dependabot and codegen) target both `main` and `develop` in parallel.** [`.github/dependabot.yml`](./.github/dependabot.yml) duplicates every ecosystem entry (one per branch) and [`.github/workflows/run-codegen-pull-request-task.yml`](./.github/workflows/run-codegen-pull-request-task.yml) runs as a matrix over both branches with branch names `codegen-main` and `codegen-develop`. Each branch absorbs its own bot PRs independently, so neither falls behind, and the forward-only rule still holds (nothing is back-merged from main to develop - both branches receive their updates directly). Parallel auto-merge across same-batch bot PRs is race-proof only because both rulesets have the strict "up to date" flag off (see bullet above). The merge-bot ([`.github/workflows/merge-bot-pull-request.yml`](./.github/workflows/merge-bot-pull-request.yml)) dispatches `--squash` or `--merge` from each PR's base ref via a `case` statement so the form matches the ruleset on either base. Dependabot **security** PRs (CVE-driven) always open against the repo default branch (`main`) regardless of `target-branch` - the same `case` statement covers them.
 - **Maintainer-pushed commits on a bot PR auto-disable auto-merge.** The merge-bot's `merge-dependabot` and `merge-codegen` jobs only fire on `opened` / `reopened` events (auto-merge is enabled exactly once per PR). When a maintainer pushes commits to a bot's branch (a `synchronize` event with an actor that isn't the same bot), the merge-bot's `disable-auto-merge-on-maintainer-push` job fires and calls `gh pr merge --disable-auto`. The maintainer's commits stay in the PR but won't auto-merge with the bot's content; re-enable auto-merge manually (`gh pr merge --auto <PR>` or the GitHub UI) when ready.
@@ -33,15 +33,17 @@ This repo uses a **two-phase model by default**: PRs build fast, publishing is b
 - **PRs smoke-test only.** [`test-pull-request.yml`](./.github/workflows/test-pull-request.yml) always runs unit tests, then a `dorny/paths-filter` `changes` job gates a **reduced, never-published** library build (`smoke: true`) that runs only when the library actually changed. Build-workflow files are intentionally not in the path filter - a filter can't tell a logic change from an action-version bump - so a workflow-only change isn't smoke-built; the reusable workflows are exercised by the next run that uses them. There is no CI workflow-lint job; lint workflow edits with `actionlint` locally before pushing.
 - **Merges don't publish by default.** [`publish-release.yml`](./.github/workflows/publish-release.yml) is the sole publisher: its **weekly schedule** (Mondays 02:00 UTC) and **manual `workflow_dispatch`** always do the full build/publish of **both** `main` and `develop` (a branch matrix). Its `push` trigger publishes only when the **`PUBLISH_ON_MERGE` repository variable** is `true` (opt-in legacy continuous-release). Unset/`false` = two-phase. Codegen runs **daily** ([`run-periodic-codegen-pull-request.yml`](./.github/workflows/run-periodic-codegen-pull-request.yml), 04:00 UTC), staggered after the weekly publish; Dependabot also runs daily - both only smoke-test on merge.
 - **Required check.** The `changes` job is in the `Check pull request workflow status` aggregator's `needs` and **must succeed** (not just "not fail") - a paths-filter error must never let a library-changing PR merge with its smoke build silently skipped. Skipped smoke jobs (no matching change) pass; `failure`/`cancelled` blocks.
-- **Reusable-task parameter contract.** [`build-release-task.yml`](./.github/workflows/build-release-task.yml) and [`build-nugetlibrary-task.yml`](./.github/workflows/build-nugetlibrary-task.yml) take `ref` (git ref to check out/version), `branch` (logical branch driving config/tags/prerelease - `main` ⇒ Release/non-prerelease, else Debug/prerelease), and where relevant `smoke`. **Branch-derived config keys off `inputs.branch`, never `github.ref_name`** - the publisher's matrix builds `develop` from a run whose `github.ref_name` is `main`, so `ref_name` would be wrong. Artifact names are branch-suffixed so both matrix legs coexist in one run. [`get-version-task.yml`](./.github/workflows/get-version-task.yml) takes a `ref` so NBGV versions the right branch, and exposes `GitCommitId` so the release tag and built artifacts pin to the exact built commit.
+- **Reusable-task parameter contract.** [`build-release-task.yml`](./.github/workflows/build-release-task.yml) and [`build-nugetlibrary-task.yml`](./.github/workflows/build-nugetlibrary-task.yml) take `ref` (git ref to check out/version), `branch` (logical branch driving config/tags/prerelease - `main` => Release/non-prerelease, else Debug/prerelease), and where relevant `smoke`. **Branch-derived config keys off `inputs.branch`, never `github.ref_name`** - the publisher's matrix builds `develop` from a run whose `github.ref_name` is `main`, so `ref_name` would be wrong. Artifact names are branch-suffixed so both matrix legs coexist in one run. [`get-version-task.yml`](./.github/workflows/get-version-task.yml) takes a `ref` so NBGV versions the right branch, and exposes `GitCommitId` so the release tag and built artifacts pin to the exact built commit.
 
-- **Versioning is semantic and maintainer-controlled.** The `version` (major.minor) in [`version.json`](./version.json) is the version floor; NBGV appends the git height (the SemVer patch position). `main` builds a stable `X.Y.<height>`; `develop` builds a prerelease `X.Y.<height>-g<sha>`. **`develop` leads `main` by a minor:** after a `develop -> main` release lands and main's publish completes, bump the minor in `version.json` on `develop` in an isolated `bump-version-X.Y` PR, so develop's prereleases sort above main's last stable (at a shared `X.Y`, develop's `X.Y.<height>-g<sha>` sorts *below* main's `X.Y.<height>`). A **maintenance** `develop -> main` promotion (dependency/codegen bumps, CI/doc fixes, template re-syncs) holds main's version - `git checkout main -- version.json` on the promotion branch - so `main` advances only its height, not its minor.
+- **Versioning is semantic and maintainer-controlled.** The `version` (major.minor) in [`version.json`](./version.json) is the version floor; NBGV appends the git height (the SemVer patch position). `main` builds a stable `X.Y.<height>`; `develop` builds a prerelease `X.Y.<height>-g<sha>`. The maintainer edits `version.json`; dependency bumps, codegen refreshes, CI/workflow fixes, doc edits, and template re-syncs leave it untouched.
+  - **Bump `version.json` only for functional changes, by maintainer instruction.** Raise the major/minor when the work warrants a new semantic version - a new feature, a behavior or API change, a breaking change - in the PR that introduces it (typically on `develop`). Do not bump on a fixed cadence or mechanically after a release.
+  - **No post-release bump; no develop-ahead requirement.** NBGV advances the patch (git height) on every commit, so a release always gets a fresh build version with no `version.json` edit and there is no `bump-version-X.Y` PR after a release. A `develop -> main` promotion carries whatever `version.json` is current: a promotion with a functional bump releases that new version on `main`; a maintenance-only promotion (dependency/codegen bumps, CI/doc fixes, template re-syncs) carries the unchanged `version.json` and `main` advances only its NBGV height.
 
 ## Pull Request Title and Commit Message Conventions
 
 ### Format
 
-- Imperative subject summarizing the change, ≤72 characters, no trailing period. ("Add ISO 639-3 retired-code handling", not "Added X" or "Adds X".)
+- Imperative subject summarizing the change, <=72 characters, no trailing period. ("Add ISO 639-3 retired-code handling", not "Added X" or "Adds X".)
 - Optional body, blank-line separated, explaining *why* the change is being made when that's non-obvious. The diff shows *what*.
 
 ### Rules
@@ -67,8 +69,21 @@ Clarify LanguageTagBuilder usage in README
 
 - Use reference-style links for any URL referenced more than once or appearing in lists; alphabetize the reference definitions block.
 - Inline single-use relative links (e.g. `[CODESTYLE.md](./CODESTYLE.md)`) are fine.
-- One logical paragraph per line; no hard-wrap line-length limit.
+- One logical paragraph per line; no hard-wrap line-length limit. For an intentional hard line break within a block - stacked badges, status, or license lines - end the line with a trailing backslash (`\`); this explicit form is preferred over trailing whitespace and is not treated as a paragraph split.
 - Headings follow the title-case-with-short-bind-words rule from the PR-title section.
+
+### Comments
+
+Applies to code and workflow (`#`) comments alike.
+
+- Comment only when the code does not explain itself or the logic is genuinely complex. Self-evident code needs no comment.
+- Write for the human reading *this* project's code now: state what the code does and only the non-obvious *why*. No cross-project references (do not name other repos), no historic or design narrative, no rule citations - governance lives in this file, not echoed inline.
+- Match the surrounding code's line length (typically ~120), not an 80-column wrap.
+
+### Line Endings
+
+- [`.editorconfig`](./.editorconfig) defines the correct ending per file type (CRLF for `.md`, `.cs`, XML/`.csproj`/`.props`, `.yml`/`.yaml`, `.json`, `.cmd`/`.bat`/`.ps1`; LF for `.sh`), and [`.gitattributes`](./.gitattributes) (`* -text`) stops git from normalizing. The defaults + per-extension EOL block is always-verbatim from the template; the `[*.cs]`/ReSharper style block is .NET-only and is carried because this repo ships .NET.
+- **Editing an existing file: preserve its current line endings** - do not reflow them as a side effect of a content change, even if the file is already non-compliant. After any programmatic edit, verify with `git diff --stat` (only changed lines) and `file <path>` (expected ending). Bring a non-compliant file to its `.editorconfig` ending only as a deliberate, isolated EOL-only change.
 
 ### Quantitative Claims
 
@@ -98,8 +113,8 @@ For each comment, classify before responding:
 
 - **Bug** - wrong behavior, missing test coverage, or a real divergence between code and docs. Fix it. Reply with the fixing commit SHA when done.
 - **Style/convention** - the comment cites a rule from this file or a language-specific style guide. Two cases:
-  - The cited rule matches what the existing codebase already does → fix the offending code.
-  - The cited rule contradicts what's in the tree, or industry norm → **update the rule instead of the code**. The rule is wrong, not the code. Bouncing the same code across rounds is the symptom of a wrong rule. Heuristic: three rounds on the same style category means the rule needs adjusting and the user should authorize the rule change.
+  - The cited rule matches what the existing codebase already does -> fix the offending code.
+  - The cited rule contradicts what's in the tree, or industry norm -> **update the rule instead of the code**. The rule is wrong, not the code. Bouncing the same code across rounds is the symptom of a wrong rule. Heuristic: three rounds on the same style category means the rule needs adjusting and the user should authorize the rule change.
 - **Architectural opinion** - the comment proposes a different design ("constrain this to disabled-by-default", "move it elsewhere", "add a runtime guardrail"). This is judgement, not a bug. Surface it to the user with a recommendation; don't apply unilaterally.
 
 ### Responding and Resolution Expectations
@@ -118,11 +133,20 @@ Bring the user in when:
 
 Anti-pattern: don't keep flipping the code on the same style point. Flip the rule once and stick to the rule.
 
+## Staying in Sync with the Template
+
+This repo is derived from [`ptr727/ProjectTemplate`](https://github.com/ptr727/ProjectTemplate) and re-syncs against it periodically, not just at creation.
+
+- **Verbatim carries.** Pull the current template version of each shared artifact and re-apply it, adapting only this repo's placeholders: [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) (the Copilot review runbook - change only the `<owner>`/`<repo>`/`<N>` values in its API snippets), [`.markdownlint-cli2.jsonc`](./.markdownlint-cli2.jsonc), [`.editorconfig`](./.editorconfig), [`.gitattributes`](./.gitattributes), and this file's [PR Review Etiquette](#pr-review-etiquette) section. The `.editorconfig` EOL/per-extension block is always-verbatim; its `[*.cs]`/ReSharper block is .NET-only and is carried here.
+- **CODESTYLE.md.** Keep [`CODESTYLE.md`](./CODESTYLE.md) as the full aggregate the template ships and re-sync the whole file, rather than hand-trimming per-language snippets.
+- **Release notes.** Keep a short release-notes summary in [`README.md`](./README.md) and the full history in [`HISTORY.md`](./HISTORY.md); update both when cutting a release.
+- **Report drift upstream.** When a re-sync surfaces a template gap, an outdated instruction, or something that bit this repo and would bite the next derived repo, open an issue in [`ptr727/ProjectTemplate`](https://github.com/ptr727/ProjectTemplate) rather than only patching locally - the template is the single source of truth, and this upstream-issue rule is this repo's only cross-repo obligation. Do not maintain or reference a "known downstream" registry, and do not name sibling repositories in docs, comments, or workflows - that registry and the maintainer fan-out duty live in the template hub only.
+
 ## Workflow YAML Conventions
 
 These conventions describe the target state. New and modified workflows must respect them; the rest of the repo is expected to be brought up to the same standard.
 
-- **Action pinning**: pin **every** action - first-party (`actions/*`) and third-party - to a commit SHA with a trailing `# vX.Y.Z` comment, so Dependabot can still bump it but a tag swap can't change the executed code. Use `# vX` (major-only) only when the upstream's floating major tag doesn't correspond to a specific patch/minor release SHA - pinning to the floating-tag SHA still gives the SHA guarantee, the version comment just records the major line. Documented exception (no SHA pin at all): [`dotnet/nbgv`](./.github/workflows/get-version-task.yml) is consumed via `@master` because the upstream tag stream lags `master` substantially and Dependabot's tag-tracking would propose a downgrade - the rationale is documented inline in that workflow.
+- **Action pinning**: pin **every** action - first-party (`actions/*`) and third-party - to a commit SHA with a trailing `# vX.Y.Z` comment, so Dependabot can still bump it but a tag swap can't change the executed code. Use `# vX` (major-only) only when the upstream's floating major tag doesn't correspond to a specific patch/minor release SHA - pinning to the floating-tag SHA still gives the SHA guarantee, the version comment just records the major line. Documented exception (no SHA pin at all): [`dotnet/nbgv`](./.github/workflows/get-version-task.yml) is consumed via `@master` because the upstream tag stream lags `master` substantially and Dependabot's tag-tracking would propose a downgrade.
 - **Filename**: reusable workflows (those with `on: workflow_call`) end in `-task.yml`. Entry-point workflows (`on: push` / `pull_request` / `schedule` / `workflow_dispatch`) do NOT use the `-task` suffix; they end with what they do - `-pull-request.yml`, `-release.yml`, etc. The suffix carries semantic meaning: a `-task.yml` file is meant to be `uses:`-d, never triggered directly.
 - **Workflow `name:`** (the top-level `name:` field): reusable workflow names end in **"task"** (e.g. `Build library task`); entry-point workflow names end in **"action"** (e.g. `Publish project release action`, `Test pull request action`). The displayed action name in the GitHub Actions UI tells you at a glance whether you're looking at an orchestrator or a callee.
 - **Job and step `name:` suffixes**: every job's `name:` ends in **"job"**; every step's `name:` ends in **"step"**. **Exception**: a job whose `name:` is also referenced as a required-status-check `context:` in a branch ruleset (currently `Check pull request workflow status` in `test-pull-request.yml`) keeps the ruleset-bound name verbatim - renaming would silently break required-status-check enforcement. Do not "fix" that name; if a future job becomes ruleset-bound, mark it the same way.
@@ -132,6 +156,7 @@ These conventions describe the target state. New and modified workflows must res
 - **Boolean inputs**: workflows triggered both via `workflow_call` and `workflow_dispatch` must declare each boolean input in *both* trigger blocks - one definition does not propagate to the other. `workflow_call` delivers booleans as actual booleans; `workflow_dispatch` delivers them as the *strings* `"true"`/`"false"`. Any `if:` consuming a boolean input must compare against both forms - `if: ${{ inputs.foo == true || inputs.foo == 'true' }}`.
 - **Reusable workflows**: job-level `permissions:` are validated *before* the `if:` evaluates, so even a skipped job needs valid permissions declared. A `release` job with `permissions: contents: write` and `if: ${{ inputs.publish }}` will still cause `startup_failure` on a caller that doesn't grant `contents: write`. Either declare permissions at the call site, or omit the inner block and inherit.
 - **Allowlist `success` and `skipped` explicitly** when chaining jobs across optional dependencies - `!= 'failure'` lets `cancelled` through (timeout, runner failure, manual cancel). Use `(needs.X.result == 'success' || needs.X.result == 'skipped')`.
+- **Artifact retention**: intermediate build artifacts (`actions/upload-artifact`) are consumed by a later job in the same run, so set `retention-days: 1` - the default 90-day retention otherwise piles up against the account-wide artifact-storage quota. The durable copies live on the GitHub release, not in workflow artifacts.
 - **Tag pinning on releases**: when using `softprops/action-gh-release` (or any tag-creating action), pass `target_commitish: ${{ github.sha }}` explicitly. Without it, GitHub's REST API defaults the new tag to the repository's default branch instead of the commit that built the artifact.
 
 ## Project Structure
@@ -147,15 +172,26 @@ These conventions describe the target state. New and modified workflows must res
 - **Build configuration**:
   - Common MSBuild properties (`TargetFramework`, `Nullable`, `ImplicitUsings`, `AnalysisLevel`, etc.) live in `Directory.Build.props` at the solution root. Do not duplicate these in individual `.csproj` files - only add a property to a `.csproj` when it is project-specific or overrides the shared default.
   - All NuGet package versions are centralised in `Directory.Packages.props`. `PackageReference` elements in `.csproj` files must not include a `Version` attribute. Asset metadata (`PrivateAssets`, `IncludeAssets`) stays in the `.csproj` `PackageReference` element.
-- **Style guide**: [`CODESTYLE.md`](./CODESTYLE.md) for C# code conventions; [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) for the Copilot review runbook and the library's public-API contract notes.
+- **Style guide**: [`CODESTYLE.md`](./CODESTYLE.md) for C# code conventions; [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) for the Copilot review runbook.
 
 ## Key Public API
 
 - `LanguageTag` - main entry point for parse/build/normalize/validate operations.
 - `LanguageTagBuilder` - fluent builder for constructing tags.
-- `LanguageLookup` - language code conversion and matching (IETF ↔ ISO).
+- `LanguageLookup` - language code conversion and matching (IETF <-> ISO).
 - `Iso6392Data`, `Iso6393Data`, `Rfc5646Data` - language data records (`Create()`, `FromDataAsync()`, `FromJsonAsync()`).
 - `ExtensionTag`, `PrivateUseTag` - sealed records for extension and private-use subtags.
 - `LogOptions` - static class for configuring library-wide logging via `ILoggerFactory`.
 
 Internal: `LanguageTagParser` - use `LanguageTag.Parse()` instead.
+
+## Library API Conventions
+
+Contract rules for the public API; honor them when changing or reviewing library code.
+
+- **Construction is factory-only.** Build tags with the static factory methods (`Parse`, `TryParse`, `ParseOrDefault`, `ParseAndNormalize`, `FromLanguage`/`FromLanguageRegion`/`FromLanguageScriptRegion`, `CreateBuilder`) or the fluent `LanguageTagBuilder`. Constructors are internal - do not expose them.
+- **Tags are immutable.** Properties have internal setters and collections are exposed as `ImmutableArray<T>`; once constructed a tag does not change. `Normalize()` returns a new copy, it does not mutate in place.
+- **Parse, validate, and normalize are distinct.** `Parse` returns null on failure; prefer `TryParse` or `ParseOrDefault` (falls back to `und`) for safe parsing. `Normalize()` does **not** validate - call `Validate()` separately when validity matters. `LanguageTagParser` is internal; all parsing goes through `LanguageTag`'s static methods.
+- **Normalization casing follows RFC 5646.** Language, extended-language, variant, extension, and private-use subtags lowercase; script Title case; region UPPERCASE.
+- **Tag semantics.** Grandfathered tags are auto-converted to their preferred values during parsing; all tag comparisons are case-insensitive; private-use tags use the `x-` prefix; extensions use single-character prefixes (except `x`, reserved for private use).
+- **Accuracy caveat.** The parsing/normalization logic may be incomplete or inaccurate per RFC 5646; verify results for the specific use case, and add a test when fixing a discrepancy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 **LanguageTags** is a C# .NET library for handling ISO 639-2, ISO 639-3, and RFC 5646 / BCP 47 language tags. The library ships as the NuGet package `ptr727.LanguageTags` and is consumed directly from `main`. The repo also contains a CLI codegen tool (`LanguageTagsCreate/`) that refreshes embedded language data from upstream registries, and an xUnit test project (`LanguageTagsTests/`).
 
-This file is the canonical reference for cross-cutting AI-agent and workflow rules. C# code-style conventions live in [`CODESTYLE.md`](./CODESTYLE.md). Copilot review *mechanics* are owned by [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) - this file delegates them there explicitly (see "PR Review Etiquette" below). High-level summaries in other docs (e.g. README's Contributing section) are allowed when they link back here; don't duplicate the rules themselves.
+This file is the canonical reference for cross-cutting AI-agent and workflow rules. C# code-style conventions live in [`CODESTYLE.md`](./CODESTYLE.md). Copilot review *mechanics* are owned by [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) - this file delegates them there explicitly (see "PR Review Etiquette" below). High-level summaries in other docs (e.g. README's Contributing section) are allowed when they link back here; don't duplicate the rules themselves. The library's **project-specific conventions and public-API/behavioral contracts** also live here (the [Library API Conventions](#library-api-conventions) section), **not** in `.github/copilot-instructions.md` - that file targets GitHub Copilot / VS Code specifically, while this file is the agent-agnostic one every coding agent reads, so any rule a reviewer must honor has to live here to be provider-independent.
 
 ## Git and Commit Rules
 
@@ -97,7 +97,7 @@ The repo runs a review loop on every PR: local agent iteration plus remote autom
 
 1. Push changes to the PR branch.
 2. Confirm a review was requested for the **current head SHA** (auto-trigger is unreliable; request explicitly).
-3. Wait for review activity on that head.
+3. Wait for review activity on that head. A completed review that raises **no findings** is a valid terminal outcome for that head - proceed; do not re-trigger it or treat the absence of comments as a missing review.
 4. Triage findings.
 5. Apply fixes or write a rationale for declines.
 6. Reply to each thread and resolve what was addressed.
@@ -137,7 +137,7 @@ Anti-pattern: don't keep flipping the code on the same style point. Flip the rul
 
 This repo is derived from [`ptr727/ProjectTemplate`](https://github.com/ptr727/ProjectTemplate) and re-syncs against it periodically, not just at creation.
 
-- **Verbatim carries.** Pull the current template version of each shared artifact and re-apply it, adapting only this repo's placeholders: [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) (the Copilot review runbook - change only the `<owner>`/`<repo>`/`<N>` values in its API snippets), [`.markdownlint-cli2.jsonc`](./.markdownlint-cli2.jsonc), [`.editorconfig`](./.editorconfig), [`.gitattributes`](./.gitattributes), and this file's [PR Review Etiquette](#pr-review-etiquette) section. The `.editorconfig` EOL/per-extension block is always-verbatim; its `[*.cs]`/ReSharper block is .NET-only and is carried here.
+- **Verbatim carries.** Pull the current template version of each shared artifact and re-apply it, adapting only this repo's placeholders: [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) (the Copilot review runbook - change only the `<owner>`/`<repo>`/`<N>` values in its API snippets), [`.markdownlint-cli2.jsonc`](./.markdownlint-cli2.jsonc), [`.editorconfig`](./.editorconfig), [`.gitattributes`](./.gitattributes), and this file's [PR Review Etiquette](#pr-review-etiquette) section. The `.editorconfig` EOL/per-extension block is always-verbatim; its `[*.cs]`/ReSharper block is .NET-only and is carried here. Keep `copilot-instructions.md` **narrow** (provider mechanics plus the commit/PR-title summary); project-specific conventions and API contracts live in this file (see [Library API Conventions](#library-api-conventions)), not there - non-Copilot agents are not directed to that file.
 - **CODESTYLE.md.** Keep [`CODESTYLE.md`](./CODESTYLE.md) as the full aggregate the template ships and re-sync the whole file, rather than hand-trimming per-language snippets.
 - **Release notes.** Keep a short release-notes summary in [`README.md`](./README.md) and the full history in [`HISTORY.md`](./HISTORY.md); update both when cutting a release.
 - **Report drift upstream.** When a re-sync surfaces a template gap, an outdated instruction, or something that bit this repo and would bite the next derived repo, open an issue in [`ptr727/ProjectTemplate`](https://github.com/ptr727/ProjectTemplate) rather than only patching locally - the template is the single source of truth, and this upstream-issue rule is this repo's only cross-repo obligation. Do not maintain or reference a "known downstream" registry, and do not name sibling repositories in docs, comments, or workflows - that registry and the maintainer fan-out duty live in the template hub only.

--- a/LanguageTags.code-workspace
+++ b/LanguageTags.code-workspace
@@ -95,7 +95,6 @@
 	"extensions": {
 		"recommendations": [
             "davidanson.vscode-markdownlint",
-            "gruntfuggly.todo-tree",
             "streetsidesoftware.code-spell-checker",
             "editorconfig.editorconfig",
             "csharpier.csharpier-vscode",
@@ -103,6 +102,7 @@
             "ms-azuretools.vscode-docker",
             "ms-dotnettools.csdevkit",
             "yzhang.markdown-all-in-one",
+            "fanaticpythoner.better-todo-tree",
 		]
 	}
 }


### PR DESCRIPTION
Re-converges with `ptr727/ProjectTemplate` develop (upstream PR #167) per the heads-up in #176, adapted to this repo's NuGet-library shape.

## Verbatim carries and docs
- `.editorconfig`: add the `.NET-only` marker before the `[*.cs]` block (the C#/ReSharper block is carried here).
- `AGENTS.md`: drop the develop-ahead / post-release-bump versioning framing; add the Comments house-rule, Line Endings note, markdown trailing-`\` rule, the `retention-days: 1` workflow convention, and a `Staying in Sync with the Template` section (report drift upstream; no sibling-repo names / no downstream registry).
- `.github/copilot-instructions.md`: re-sync the Copilot review runbook to the current template (GraphQL `requestReviews`, REST vs GraphQL reviewer-login `[bot]` fix, mutation-based retry); drop the stale `## Versioning` block.

## Project-rule consolidation
- Move the library's API-design rules and contract notes into `AGENTS.md` (new `Library API Conventions` section) so every agent reads them, not just Copilot/VS Code; slim `.github/copilot-instructions.md` back to the narrow provider-mechanics shape. Upstream clarification filed as ptr727/ProjectTemplate#173.

## Workflows
- `retention-days: 1` on the intermediate build artifact in `build-nugetlibrary-task.yml`.
- House-rule comment trims across the carried workflows (historic narrative, rule citations, and non-ASCII em-dashes removed); logic, CRLF, and SHA pins unchanged. The wrapper-only `merge-upstream-version` job is intentionally not added.

## Out of scope
- Pre-existing LF/CRLF drift (`AGENTS.md` and the `.yml` workflows are stored LF though `.editorconfig` mandates CRLF) is left untouched per the "don't reflow endings" rule; a deliberate EOL-only normalization can follow separately.

## Verification
- `dotnet build`: 0 warnings / 0 errors. `dotnet test`: 257/257 pass.
- actionlint clean on edited workflows; markdownlint 0 errors; no non-ASCII in edited files; line endings preserved.

Addresses #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)