### PR TITLE
Replace test #pragma suppressions with SuppressMessage and null-forgiving

### DIFF
--- a/LanguageTagsTests/LanguageTagTests.cs
+++ b/LanguageTagsTests/LanguageTagTests.cs
@@ -249,6 +249,7 @@ public class LanguageTagTests : SingleInstanceFixture
     {
         LanguageTag tag = LanguageTag.Parse("en-US")!;
         _ = tag.Equals(null).Should().BeFalse();
+        // tag is non-null; ! avoids a CS8602 false-positive on the Equals(object?) receiver.
         _ = tag!.Equals((object?)null).Should().BeFalse();
     }
 

--- a/LanguageTagsTests/LanguageTagTests.cs
+++ b/LanguageTagsTests/LanguageTagTests.cs
@@ -249,9 +249,7 @@ public class LanguageTagTests : SingleInstanceFixture
     {
         LanguageTag tag = LanguageTag.Parse("en-US")!;
         _ = tag.Equals(null).Should().BeFalse();
-#pragma warning disable CS8602
-        _ = tag.Equals((object?)null).Should().BeFalse();
-#pragma warning restore CS8602
+        _ = tag!.Equals((object?)null).Should().BeFalse();
     }
 
     [Fact]
@@ -282,14 +280,17 @@ public class LanguageTagTests : SingleInstanceFixture
     }
 
     [Fact]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Maintainability",
+        "CA1508:Avoid dead conditional code",
+        Justification = "Test intentionally compares two null tags to exercise operator== with both operands null."
+    )]
     public void OperatorEquals_BothNull_ReturnsTrue()
     {
         LanguageTag? tag1 = null;
         LanguageTag? tag2 = null;
 
-#pragma warning disable CA1508 // Avoid dead conditional code
         _ = (tag1 == tag2).Should().BeTrue();
-#pragma warning restore CA1508
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to the template re-sync (#182): `CODESTYLE.md` now bans `#pragma warning disable` in favor of `[SuppressMessage]` / `.editorconfig`. Two test cases in `LanguageTagTests.cs` used `#pragma`; this conforms them to the rule. Surfaced by Copilot on #183.

## Changes

- **CA1508** (analyzer - *"'tag1 == tag2' is always true"*): annotate `OperatorEquals_BothNull_ReturnsTrue` with `[SuppressMessage]` + `Justification`. The test deliberately compares two null tags to exercise `operator==` with both operands null.
- **CS8602** (compiler nullable warning): `[SuppressMessage]` cannot suppress compiler `CS####` diagnostics, only `#pragma`/`NoWarn` or code can. Replaced the `#pragma` with the null-forgiving operator on the `Equals(object?)` receiver - idiomatic and rule-compliant (CODESTYLE bans `#pragma`, not `!`).

No `#pragma warning` directives remain in the codebase.

## Verification

- `dotnet build` (no-incremental): 0 warnings / 0 errors
- `dotnet format style --verify-no-changes`: clean
- `dotnet test`: 257/257 pass