### PR TITLE
Re-sync release-workflow fixes from template (#213/#214)

### DIFF
--- a/.github/workflows/build-nugetlibrary-task.yml
+++ b/.github/workflows/build-nugetlibrary-task.yml
@@ -37,6 +37,7 @@ jobs:
     secrets: inherit
     with:
       ref: ${{ inputs.ref }}
+      branch: ${{ inputs.branch }}
 
   build-nugetlibrary:
     name: Build NuGet library project job

--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -164,11 +164,15 @@ jobs:
             ./Publish/*
 
       # Surgical cleanup at the point of consumption: the release-asset-<branch>-* transfer artifacts now have durable
-      # copies on the release, so delete them by exact pattern. Best-effort (the release already published): a hiccup
-      # must not red the job; the retention-days: 1 backstop reaps anything missed. Deletes every matching id.
-      # Needs the caller to grant `actions: write` (publish-release's publish job does).
+      # copies on the release, so delete them by exact pattern to free the storage quota - scoped to this branch's
+      # assets, leaving diagnostics and any other artifacts. Gated to the same condition as the create step so it only
+      # deletes when a release was actually created/refreshed this run; on a skipped create (existing tag, no new
+      # commits) the fresh artifacts stay for the run, reaped by the retention-days: 1 backstop. Needs the caller to
+      # grant `actions: write` (publish-release's publish job does).
       - name: Delete consumed release asset artifacts step
-        if: ${{ inputs.expect_release_assets }}
+        if: ${{ inputs.expect_release_assets && (steps.release-exists.outputs.exists == 'false' || github.event_name == 'workflow_dispatch') }}
+        # Best-effort: the release is already published, so a listing/delete hiccup must never red the job; the
+        # retention-days: 1 backstop reaps anything missed. Deletes every matching id (a rerun can upload duplicates).
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -166,7 +166,7 @@ jobs:
       # Surgical cleanup at the point of consumption: the release-asset-<branch>-* transfer artifacts now have durable
       # copies on the release, so delete them by exact pattern. Best-effort (the release already published): a hiccup
       # must not red the job; the retention-days: 1 backstop reaps anything missed. Deletes every matching id.
-      # Needs the caller to grant `actions: write` (publish-release's publish job does, see B2).
+      # Needs the caller to grant `actions: write` (publish-release's publish job does).
       - name: Delete consumed release asset artifacts step
         if: ${{ inputs.expect_release_assets }}
         continue-on-error: true

--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -50,11 +50,38 @@ jobs:
     secrets: inherit
     with:
       ref: ${{ inputs.ref }}
+      branch: ${{ inputs.branch }}
+
+  # Entry gate: validate branch<->version consistency once, before the build jobs, so an NBGV mis-classification fails
+  # fast instead of after building and publishing. main must be a public release (no prerelease '-'); every other branch
+  # must carry a prerelease '-' (guards a develop leg being classified public and published as stable). Strip
+  # '+buildmetadata' first; a '-' there is legitimate, only a '-' in the core/prerelease segment marks a prerelease.
+  validate-release:
+    name: Validate release version job
+    needs: [get-version]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch and version consistency step
+        env:
+          SEMVER2: ${{ needs.get-version.outputs.SemVer2 }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          set -euo pipefail
+          CORE_AND_PRE="${SEMVER2%%+*}"
+          if [[ "$BRANCH" == "main" ]]; then
+            if [[ "$CORE_AND_PRE" == *-* ]]; then
+              echo "::error::Public (main) release version '$SEMVER2' carries a prerelease suffix; refusing to publish."
+              exit 1
+            fi
+          elif [[ "$CORE_AND_PRE" != *-* ]]; then
+            echo "::error::Prerelease ($BRANCH) version '$SEMVER2' has no prerelease suffix (NBGV classified it public); refusing to publish."
+            exit 1
+          fi
 
   build-nugetlibrary:
     name: Build NuGet library job
     if: ${{ inputs.enable_nuget }}
-    needs: [get-version]
+    needs: [get-version, validate-release]
     uses: ./.github/workflows/build-nugetlibrary-task.yml
     secrets: inherit
     with:
@@ -72,7 +99,7 @@ jobs:
     # `github: true` still can't create a release.
     if: ${{ inputs.github && !inputs.smoke }}
     runs-on: ubuntu-latest
-    needs: [get-version, build-nugetlibrary]
+    needs: [get-version, validate-release, build-nugetlibrary]
 
     steps:
 
@@ -81,21 +108,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.get-version.outputs.GitCommitId }}
-
-      # Backstop (main only): a public release must not carry a prerelease '-', guarding against NBGV mis-versioning the
-      # public ref (e.g. a dispatch on a non-default ref) into a malformed "Latest" release. Strip '+buildmetadata'
-      # first - a '-' there is legitimate; only a '-' in the core/prerelease segment marks a prerelease.
-      - name: Verify public release version step
-        if: ${{ inputs.branch == 'main' }}
-        env:
-          SEMVER2: ${{ needs.get-version.outputs.SemVer2 }}
-        run: |
-          set -euo pipefail
-          CORE_AND_PRE="${SEMVER2%%+*}"   # drop +buildmetadata; a '-' here is the genuine prerelease separator
-          if [[ "$CORE_AND_PRE" == *-* ]]; then
-            echo "::error::Public (main) release version '$SEMVER2' carries a prerelease suffix; refusing to publish."
-            exit 1
-          fi
 
       # Collect assets by the `release-asset-<branch>-*` pattern so this step is target-agnostic: subset releases by
       # deleting the target, not `enable_*: false` (a skipped `needs` job would skip this release job too). The release
@@ -150,3 +162,24 @@ jobs:
             LICENSE
             README.md
             ./Publish/*
+
+      # Surgical cleanup at the point of consumption: the release-asset-<branch>-* transfer artifacts now have durable
+      # copies on the release, so delete them by exact pattern. Best-effort (the release already published): a hiccup
+      # must not red the job; the retention-days: 1 backstop reaps anything missed. Deletes every matching id.
+      # Needs the caller to grant `actions: write` (publish-release's publish job does, see B2).
+      - name: Delete consumed release asset artifacts step
+        if: ${{ inputs.expect_release_assets }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! ids=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/${{ github.run_id }}/artifacts" --paginate \
+            --jq ".artifacts[] | select(.name | startswith(\"release-asset-${{ inputs.branch }}-\")) | .id"); then
+            echo "::warning::Could not list run artifacts; retention-days backstop will reap them."
+            ids=""
+          fi
+          for id in $ids; do
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/actions/artifacts/$id" \
+              || echo "::warning::Failed to delete artifact $id; retention-days backstop will reap it."
+          done

--- a/.github/workflows/get-version-task.yml
+++ b/.github/workflows/get-version-task.yml
@@ -9,6 +9,12 @@ on:
         required: false
         type: string
         default: ''
+      # Logical branch NBGV classifies against. Pins PublicRelease to this branch instead of the runner's GITHUB_REF,
+      # which on a publish dispatched from the default branch is that branch for every matrix leg. Empty keeps GITHUB_REF.
+      branch:
+        required: false
+        type: string
+        default: ''
     outputs:
       SemVer2:
         value: ${{ jobs.get-version.outputs.SemVer2 }}
@@ -52,3 +58,8 @@ jobs:
       - name: Run Nerdbank.GitVersioning tool step
         id: nbgv
         uses: dotnet/nbgv@master
+        env:
+          # NBGV reads the branch from GITHUB_REF; pin it to the leg being versioned so a publish dispatched from the
+          # default branch doesn't classify every leg as the public ref and strip its prerelease suffix.
+          GITHUB_REF: ${{ inputs.branch != '' && format('refs/heads/{0}', inputs.branch) || github.ref }}
+          GITHUB_REF_NAME: ${{ inputs.branch != '' && inputs.branch || github.ref_name }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -78,6 +78,8 @@ jobs:
     secrets: inherit
     permissions:
       contents: write
+      # actions:write lets the github-release job delete the release-asset-* artifacts it consumes (surgical cleanup).
+      actions: write
     with:
       ref: ${{ matrix.branch }}
       branch: ${{ matrix.branch }}
@@ -96,29 +98,3 @@ jobs:
     secrets: inherit
     permissions:
       contents: write
-
-  # Delete the run's artifacts (durable copies live on the GitHub release) to keep them off the account storage quota.
-  cleanup-artifacts:
-    name: Delete workflow artifacts job
-    needs: [setup, publish, date-badge]
-    if: ${{ always() && needs.setup.outputs.publish == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Delete workflow artifacts step
-        # Best-effort housekeeping must never fail the run.
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          if ! ids=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts --paginate \
-            --jq '.artifacts[].id'); then
-            echo "::warning::Could not list run artifacts; skipping cleanup."
-            ids=""
-          fi
-          for artifact_id in $ids; do
-            gh api --method DELETE "repos/${{ github.repository }}/actions/artifacts/$artifact_id" \
-              || echo "::warning::Failed to delete artifact $artifact_id; continuing."
-          done

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -115,30 +115,3 @@ jobs:
           # smoke-build may be legitimately skipped (library unchanged); only failure/cancelled blocks.
           exit_on_result "unit-test" "${{ needs.unit-test.result }}"
           exit_on_result "smoke-build" "${{ needs.smoke-build.result }}"
-
-  # Delete any incidental artifacts a build step emitted to keep them off the account storage quota. Kept out of
-  # `check-workflow-status`'s needs so housekeeping never gates the required merge check.
-  cleanup-artifacts:
-    name: Delete workflow artifacts job
-    needs: [smoke-build]
-    if: always()
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Delete workflow artifacts step
-        # Best-effort housekeeping must never fail the run.
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          if ! ids=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts --paginate \
-            --jq '.artifacts[].id'); then
-            echo "::warning::Could not list run artifacts; skipping cleanup."
-            ids=""
-          fi
-          for artifact_id in $ids; do
-            gh api --method DELETE "repos/${{ github.repository }}/actions/artifacts/$artifact_id" \
-              || echo "::warning::Failed to delete artifact $artifact_id; continuing."
-          done


### PR DESCRIPTION
Implements the re-sync task in #195 — the single-target adaptation of template PRs ptr727/ProjectTemplate#215 (#213) and ptr727/ProjectTemplate#216 (#214).

## #213 — develop leg published as a stable NuGet package

NBGV derives `PublicRelease` from the CI branch (`GITHUB_REF`). On a publish dispatched from `main`, every matrix leg saw `GITHUB_REF=refs/heads/main`, so the `develop` leg was classified public and its `-g<sha>` prerelease suffix stripped → published to NuGet as a stable version.

- `get-version-task.yml`: add a `branch` input; pin `GITHUB_REF`/`GITHUB_REF_NAME` for the NBGV step to the leg's branch.
- Thread `branch` into both `get-version` callers (`build-release-task.yml`, `build-nugetlibrary-task.yml`).
- `build-release-task.yml`: replace the main-only verify step with a `validate-release` **entry gate** that fails fast in both directions — `main` must be public (no prerelease `-`), every other branch must carry one.

## #214 — blanket artifact cleanup destroyed diagnostics

The `cleanup-artifacts` job deleted **all** run artifacts (`.artifacts[].id`), taking logs/diagnostics with the transfer artifacts.

- `build-release-task.yml`: surgically delete only the consumed `release-asset-<branch>-*` artifacts at the point of consumption (best-effort; `retention-days: 1` backstop).
- `publish-release.yml` / `test-pull-request.yml`: remove the blanket `cleanup-artifacts` job; grant `actions: write` to the publish job.

## Testing

- **NBGV mechanism proven** locally: `GITHUB_REF=refs/heads/main` → `PublicRelease=True`, `1.4.1` (reproduces the bug); `GITHUB_REF=refs/heads/develop` → `PublicRelease=False`, `1.4.1-g10cc912fcd` (fixed).
- **`validate-release` truth table** verified (8 cases): catches `develop`+clean version, allows `develop`+`-g<sha>`, allows `main` public, rejects `main`+prerelease, handles `+buildmetadata`.
- `actionlint` clean; CRLF preserved on all five workflow files; job dependency graph intact.

Closes #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)