### PR TITLE
Release: promote develop to main (IGNORE_GITHUB_REF prerelease fix)

### DIFF
--- a/.github/workflows/build-nugetlibrary-task.yml
+++ b/.github/workflows/build-nugetlibrary-task.yml
@@ -37,7 +37,6 @@ jobs:
     secrets: inherit
     with:
       ref: ${{ inputs.ref }}
-      branch: ${{ inputs.branch }}
 
   build-nugetlibrary:
     name: Build NuGet library project job

--- a/.github/workflows/build-nugetlibrary-task.yml
+++ b/.github/workflows/build-nugetlibrary-task.yml
@@ -37,6 +37,7 @@ jobs:
     secrets: inherit
     with:
       ref: ${{ inputs.ref }}
+      branch: ${{ inputs.branch }}
 
   build-nugetlibrary:
     name: Build NuGet library project job

--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -64,8 +64,16 @@ jobs:
         env:
           SEMVER2: ${{ needs.get-version.outputs.SemVer2 }}
           BRANCH: ${{ inputs.branch }}
+          SMOKE: ${{ inputs.smoke }}
         run: |
           set -euo pipefail
+          # This gate guards real publishes. A smoke build checks out the PR head in detached HEAD, so NBGV always
+          # yields a prerelease version; on a main-base PR that would trip the public-release check and fail every
+          # develop->main promotion that carries a build target. Skip the gate for smoke builds (they never publish).
+          if [[ "$SMOKE" == "true" ]]; then
+            echo "Smoke build; skipping release version validation."
+            exit 0
+          fi
           CORE_AND_PRE="${SEMVER2%%+*}"
           if [[ "$BRANCH" == "main" ]]; then
             if [[ "$CORE_AND_PRE" == *-* ]]; then

--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -50,6 +50,7 @@ jobs:
     secrets: inherit
     with:
       ref: ${{ inputs.ref }}
+      branch: ${{ inputs.branch }}
 
   # Entry gate: validate branch<->version consistency once, before the build jobs, so an NBGV mis-classification fails
   # fast instead of after building and publishing. main must be a public release (no prerelease '-'); every other branch

--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -50,7 +50,6 @@ jobs:
     secrets: inherit
     with:
       ref: ${{ inputs.ref }}
-      branch: ${{ inputs.branch }}
 
   # Entry gate: validate branch<->version consistency once, before the build jobs, so an NBGV mis-classification fails
   # fast instead of after building and publishing. main must be a public release (no prerelease '-'); every other branch

--- a/.github/workflows/get-version-task.yml
+++ b/.github/workflows/get-version-task.yml
@@ -9,12 +9,6 @@ on:
         required: false
         type: string
         default: ''
-      # Logical branch NBGV classifies against. Pins PublicRelease to this branch instead of the runner's GITHUB_REF,
-      # which on a publish dispatched from the default branch is that branch for every matrix leg. Empty keeps GITHUB_REF.
-      branch:
-        required: false
-        type: string
-        default: ''
     outputs:
       SemVer2:
         value: ${{ jobs.get-version.outputs.SemVer2 }}
@@ -59,7 +53,8 @@ jobs:
         id: nbgv
         uses: dotnet/nbgv@master
         env:
-          # NBGV reads the branch from GITHUB_REF; pin it to the leg being versioned so a publish dispatched from the
-          # default branch doesn't classify every leg as the public ref and strip its prerelease suffix.
-          GITHUB_REF: ${{ inputs.branch != '' && format('refs/heads/{0}', inputs.branch) || github.ref }}
-          GITHUB_REF_NAME: ${{ inputs.branch != '' && inputs.branch || github.ref_name }}
+          # NBGV's GitHub Actions cloud-build provider overrides the checked-out branch with GITHUB_REF (the dispatch
+          # ref). On a publish dispatched from the default branch that misclassifies every matrix leg as the public ref
+          # and strips the prerelease suffix. GITHUB_REF is reserved and cannot be reliably overridden, so tell NBGV to
+          # ignore it and version from the actually-checked-out branch (each leg checks out its own branch).
+          IGNORE_GITHUB_REF: true

--- a/.github/workflows/get-version-task.yml
+++ b/.github/workflows/get-version-task.yml
@@ -9,6 +9,13 @@ on:
         required: false
         type: string
         default: ''
+      # Logical branch NBGV classifies public-vs-prerelease against. With IGNORE_GITHUB_REF, NBGV reads the
+      # checked-out git branch; callers that check out a pinned commit (detached HEAD - the build jobs) pass this
+      # so a local branch can be created at that commit, giving NBGV the right name. Empty leaves the checkout as-is.
+      branch:
+        required: false
+        type: string
+        default: ''
     outputs:
       SemVer2:
         value: ${{ jobs.get-version.outputs.SemVer2 }}
@@ -46,6 +53,16 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
+
+      # NBGV (with IGNORE_GITHUB_REF) classifies public-vs-prerelease from the checked-out branch. A pinned-SHA
+      # checkout is detached HEAD, where NBGV sees no branch and treats every leg as prerelease (the main leg would
+      # then build a prerelease package mismatching its clean release tag). Force a local branch at HEAD matching the
+      # logical branch so NBGV sees the right name while still versioning the intended commit.
+      - name: Pin logical branch step
+        if: ${{ inputs.branch != '' }}
+        env:
+          BRANCH: ${{ inputs.branch }}
+        run: git checkout -B "$BRANCH"
 
       # nbgv is floated on @master: its tag stream lags master, so Dependabot tag-tracking would propose a downgrade.
       # Revisit if dotnet/nbgv resumes regular tagged releases.


### PR DESCRIPTION
Promotes `develop` to `main` to deploy the corrected prerelease-tagging fix (#198) so the next publish exercises it.

- **#198** — `IGNORE_GITHUB_REF=true` makes NBGV version from the checked-out branch (the prior `GITHUB_REF` override from #196 was ineffective — reserved var). CI-verified: develop checkout → `1.4.x-g<sha>` prerelease, main → stable.

Merge commit (not squash). A `publish-release.yml` dispatch after this lands will confirm the develop leg publishes a true pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)