### PR TITLE
Fix trusted-publishing docs: policy names build-release-task.yml

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -322,7 +322,8 @@ applicable guarantee is not operational (section 1).
   GitHub OIDC token for a temporary key, using the `NUGET_USERNAME` profile name), and `dotnet nuget push`
   uses that key. There is **no** long-lived `NUGET_API_KEY` secret. The key is requested immediately
   before the push (1-hour lifetime, single use). The matching trusted-publishing policy on NuGet.org
-  (section 6) names the entry workflow `publish-release.yml`. *Prevents: a leaked long-lived publish
+  (section 6) names `build-release-task.yml`, the reusable task that requests the token (the OIDC
+  `job_workflow_ref`), not the `publish-release.yml` entry workflow. *Prevents: a leaked long-lived publish
   credential.*
 
 ### D5 - Resource cleanup
@@ -535,8 +536,10 @@ in its own right, not merely discoverable by failure (D10; audit 5D).
 
 **NuGet.org trusted-publishing policy.** Publishing is keyless via OIDC (D4.7), so a trusted-publishing
 policy must exist in the NuGet.org account naming Repository Owner `ptr727`, Repository `LanguageTags`, and
-Workflow File `publish-release.yml` (filename only). It lives on NuGet.org, not GitHub, so `configure.sh`
-cannot read it - a manual checklist item. A private-repo policy stays provisional for 7 days until the
+Workflow File `build-release-task.yml` (filename only) - the reusable task that runs `NuGet/login` and
+requests the token, which the OIDC `job_workflow_ref` claim names rather than the `publish-release.yml`
+entry workflow. It lives on NuGet.org, not GitHub, so `configure.sh` cannot read it - a manual checklist
+item. A private-repo policy stays provisional for 7 days until the
 first successful publish locks it to the repo and owner IDs.
 
 **Branch rulesets.**

--- a/repo-config/configure.sh
+++ b/repo-config/configure.sh
@@ -153,7 +153,7 @@ cmd_check() {
   check_app
   # External, not checkable via gh api: the NuGet.org trusted-publishing policy that makes publishing
   # keyless (WORKFLOW.md D4.7). Verify it by hand in the nuget.org account.
-  note "verify manually: NuGet.org trusted-publishing policy (owner ptr727, repo LanguageTags, workflow publish-release.yml)"
+  note "verify manually: NuGet.org trusted-publishing policy (owner ptr727, repo LanguageTags, workflow build-release-task.yml)"
   if [[ "$FAILED" -ne 0 ]]; then echo "Configuration drift detected."; exit 1; fi
   echo "Configuration matches."
 }


### PR DESCRIPTION
The OIDC token is requested by `NuGet/login` inside the reusable `build-release-task.yml`, so its `job_workflow_ref` names that file, not the `publish-release.yml` entry workflow. The NuGet.org trusted-publishing policy must name `build-release-task.yml`.

Found by the first real publish (1.5 prerelease on develop): `Token exchange failed (HTTP 401) ... Workflow mismatch for policy 'LanguageTags': expected 'publish-release.yml', actual 'build-release-task.yml'`. Policy already repointed to `build-release-task.yml`; this corrects WORKFLOW.md D4.7 / section 6 and `configure.sh` to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)