### PR TITLE
Address Copilot: D9 ordering and capitalization

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -393,12 +393,12 @@ applicable guarantee is not operational (section 1).
   required-check `context:` is codified in `repo-config/` and changed only in lockstep with the ruleset.
 - **D9.3** Bash `run:` blocks start `set -euo pipefail`; multi-line `if:` uses `>-`.
 - **D9.4** Line endings follow `.editorconfig`.
-- **D9.6** Style is enforced in CI, not just the editor: the `lint` job (D1.3) runs CSharpier check,
-  `dotnet format style`, `markdownlint-cli2`, `cspell` on the user-facing docs, and `actionlint`, from the
-  same config files the editor and the Husky hook use (CODESTYLE clean-compile sync).
 - **D9.5** No decorative / non-shipped workflow remains, in particular no date-badge workflow
   (`build-datebadge-*`). The contract ships exactly the package and its release. A workflow that produces
   neither is out of scope, and its presence is a defect to remove.
+- **D9.6** Style is enforced in CI, not just the editor: the `lint` job (D1.3) runs CSharpier check,
+  `dotnet format style`, `markdownlint-cli2`, `cspell` on the user-facing docs, and `actionlint`, from the
+  same config files the editor and the Husky hook use (CODESTYLE clean-compile sync).
 
 ### D10 - Repository configuration
 

--- a/repo-config/README.md
+++ b/repo-config/README.md
@@ -49,8 +49,8 @@ REPO=ptr727/LanguageTags ./repo-config/configure.sh check   # confirm no drift
 ```
 
 First-time adoption is the same step: the live ruleset predates the renamed aggregator, so the first
-`apply` is what lets a pull request against the new workflows go green. both modes need a `gh` login
-with admin on the repo (the rulesets and secrets endpoints require it); `apply` writes, `check` only
+`apply` is what lets a pull request against the new workflows go green. Both modes need a `gh` login
+with admin on the repo (the rulesets and secrets endpoints require it). `apply` writes, `check` only
 reads.
 
 ## Why both a script and JSON


### PR DESCRIPTION
Two small doc corrections from Copilot's review of the promotion PR: reorder D9.5/D9.6 in WORKFLOW.md, and fix a lowercase sentence start in repo-config/README.md. The snupkg note was a false positive (the 1.5.1 publish log confirms the .snupkg was pushed to the symbol endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)