### PR TITLE
Ensure 7z is available before archiving

### DIFF
--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -148,7 +148,10 @@ jobs:
         if: ${{ inputs.publish && !inputs.smoke }}
         run: |
           set -euo pipefail
-          command -v 7z >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y p7zip-full; }
+          if ! command -v 7z >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends p7zip-full
+          fi
           cd ${{ runner.temp }}/publish
           7z a -t7z ${{ runner.temp }}/LanguageTags.7z ./*
 

--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -148,6 +148,7 @@ jobs:
         if: ${{ inputs.publish && !inputs.smoke }}
         run: |
           set -euo pipefail
+          command -v 7z >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y p7zip-full; }
           cd ${{ runner.temp }}/publish
           7z a -t7z ${{ runner.temp }}/LanguageTags.7z ./*
 


### PR DESCRIPTION
Defensive install of p7zip-full only when 7z is missing, so a future ubuntu-latest change can't break the release archive step (no-op on current runners, which ship p7zip-full). Addresses Copilot's recurring note on the compress step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)