### PR TITLE
Make jq_lacks set -e-safe

### DIFF
--- a/repo-config/configure.sh
+++ b/repo-config/configure.sh
@@ -87,7 +87,8 @@ jq_has() { jq -e "$@" >/dev/null 2>&1; }
 
 # jq_lacks FILTER... - true iff the jq filter selects nothing (jq exit 1). A real jq error (exit >1, e.g. a
 # malformed filter or input) is propagated, not treated as "lacks", so the calling assert fails loudly.
-jq_lacks() { local rc; jq -e "$@" >/dev/null 2>&1; rc=$?; case "$rc" in 0) return 1 ;; 1) return 0 ;; *) return "$rc" ;; esac; }
+# The `|| rc=$?` keeps jq in a list (exempt from set -e) so an exit-1 no-match captures rc instead of aborting.
+jq_lacks() { local rc=0; jq -e "$@" >/dev/null 2>&1 || rc=$?; case "$rc" in 1) return 0 ;; 0) return 1 ;; *) return "$rc" ;; esac; }
 
 check_ruleset() { # name  expected-merge-method  expect-linear(true/false)
   local name="$1" method="$2" linear="$3" id rs


### PR DESCRIPTION
Capture jq's exit code with `|| rc=$?` (a list is exempt from errexit) so an exit-1 no-match returns 'lacks' rather than risking a `set -e` abort outside a conditional, while still propagating a real jq error (>1). Verified under `set -euo pipefail` for match / no-match / jq-error. Follow-up to PR #211.