### PR TITLE
Sync section 0 shipped-input list with the glossary

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -17,7 +17,8 @@ Each guarantee names the **failure it prevents**, so the reason survives a reimp
 A run targets **one branch, the one it was triggered on** (`github.ref_name`): `main` builds a stable
 release, `develop` a prerelease. The version is computed once and threaded downstream. A pull request
 builds and tests but never publishes. The package **publishes itself** when a shipped input changes (the
-source, the embedded data, the version floor, or the build configuration), so releases track the code
+source, the embedded data, the version floor, the build configuration, or the package versions - so a
+dependency bump republishes to keep the package's dependencies current), so releases track the code
 without a person cutting them. A maintainer dispatches only to force a release. Dependabot and codegen
 pull requests merge themselves once their checks pass.
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -17,8 +17,9 @@ Each guarantee names the **failure it prevents**, so the reason survives a reimp
 A run targets **one branch, the one it was triggered on** (`github.ref_name`): `main` builds a stable
 release, `develop` a prerelease. The version is computed once and threaded downstream. A pull request
 builds and tests but never publishes. The package **publishes itself** when a shipped input changes (the
-source, the embedded data, the version floor, the build configuration, or the package versions - so a
-dependency bump republishes to keep the package's dependencies current), so releases track the code
+source, the embedded data, the version floor, the build configuration, or the package versions
+(`Directory.Packages.props`) - so a dependency bump republishes to keep the package's declared dependencies
+current), so releases track the code
 without a person cutting them. A maintainer dispatches only to force a release. Dependabot and codegen
 pull requests merge themselves once their checks pass.
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -16,11 +16,11 @@ Each guarantee names the **failure it prevents**, so the reason survives a reimp
 
 A run targets **one branch, the one it was triggered on** (`github.ref_name`): `main` builds a stable
 release, `develop` a prerelease. The version is computed once and threaded downstream. A pull request
-builds and tests but never publishes. The package **publishes itself** when a shipped input changes (the
+builds and tests but never publishes. The package **publishes itself** when a shipped input changes - the
 source, the embedded data, the version floor, the build configuration, or the package versions
-(`Directory.Packages.props`) - so a dependency bump republishes to keep the package's declared dependencies
-current), so releases track the code
-without a person cutting them. A maintainer dispatches only to force a release. Dependabot and codegen
+(`Directory.Packages.props`) - so releases track the code without a person cutting them. Listing the package
+versions means a dependency bump republishes too, keeping the package's declared dependencies current. A
+maintainer dispatches only to force a release. Dependabot and codegen
 pull requests merge themselves once their checks pass.
 
 ### Glossary


### PR DESCRIPTION
Section 0's model-at-a-glance omitted package versions from the shipped-input list (the glossary/D4.1 include them). Add it. Follow-up to #211/#212.