### PR TITLE
Fix directional reference in publisher comment

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,7 @@ name: Publish project release action
 #
 # - Trigger: a push that changes a shipped input (the on.push.paths inclusion list below - library source,
 #   embedded data, version floor, build configuration, or package versions), or a workflow_dispatch.
-# - Inclusion-only: add a path above when a new input starts affecting the shipped package. Package versions
+# - Inclusion-only: add a path to that list when a new input starts affecting the shipped package. Package versions
 #   (Directory.Packages.props) ARE listed: a NuGet package cannot be rebuilt on a cadence (a version can't be
 #   re-pushed), so a dependency bump must republish to keep the package's declared dependencies current - this
 #   closes the stale/vulnerable-dependency window. GitHub Actions bumps are not listed (they do not ship in


### PR DESCRIPTION
The on.push.paths inclusion list is below the header comment; change 'add a path above' to 'add a path to that list'. Follow-up to #211/#212.