### PR TITLE
Fix jq_lacks exit-4 bug; correct App-install README

### DIFF
--- a/repo-config/README.md
+++ b/repo-config/README.md
@@ -31,7 +31,8 @@ templates); repository administration config-as-code is the maintainer's, so it 
 
 Secret **values** are never readable through the API, so the script only asserts the required secret
 **names** exist (`NUGET_USERNAME` and the App credentials `CODEGEN_APP_CLIENT_ID` /
-`CODEGEN_APP_PRIVATE_KEY`) and that a GitHub App is installed. Set the values in the repository (or
+`CODEGEN_APP_PRIVATE_KEY`), and *notes* (best-effort) whether a GitHub App is installed - a precise check
+needs app-level auth, so that one does not fail the audit. Set the values in the repository (or
 organization) secret store directly. Publishing is keyless via OIDC trusted publishing (WORKFLOW.md
 D4.7), so there is no `NUGET_API_KEY`; the matching trusted-publishing policy lives on NuGet.org and is
 verified by hand, not by this script.

--- a/repo-config/README.md
+++ b/repo-config/README.md
@@ -32,7 +32,7 @@ templates); repository administration config-as-code is the maintainer's, so it 
 Secret **values** are never readable through the API, so the script only asserts the required secret
 **names** exist (`NUGET_USERNAME` and the App credentials `CODEGEN_APP_CLIENT_ID` /
 `CODEGEN_APP_PRIVATE_KEY`), and *notes* (best-effort) whether a GitHub App is installed - a precise check
-needs app-level auth, so that one does not fail the audit. Set the values in the repository (or
+needs app-level auth, so the App-installation check does not fail the audit. Set the values in the repository (or
 organization) secret store directly. Publishing is keyless via OIDC trusted publishing (WORKFLOW.md
 D4.7), so there is no `NUGET_API_KEY`; the matching trusted-publishing policy lives on NuGet.org and is
 verified by hand, not by this script.

--- a/repo-config/configure.sh
+++ b/repo-config/configure.sh
@@ -85,10 +85,12 @@ assert() {
 # caller's. Reads JSON from stdin.
 jq_has() { jq -e "$@" >/dev/null 2>&1; }
 
-# jq_lacks FILTER... - true iff the jq filter selects nothing (jq exit 1). A real jq error (exit >1, e.g. a
-# malformed filter or input) is propagated, not treated as "lacks", so the calling assert fails loudly.
-# The `|| rc=$?` keeps jq in a list (exempt from set -e) so an exit-1 no-match captures rc instead of aborting.
-jq_lacks() { local rc=0; jq -e "$@" >/dev/null 2>&1 || rc=$?; case "$rc" in 1) return 0 ;; 0) return 1 ;; *) return "$rc" ;; esac; }
+# jq_lacks FILTER... - true iff the jq filter yields no truthy value (selects nothing, or only false/null).
+# `jq -e` exits 1 (last output false/null) or 4 (no output at all) for the "lacks" cases, 0 for a truthy
+# match, and 2/3/5 for a real error (malformed filter or input), which is propagated so the calling assert
+# fails loudly. The `|| rc=$?` keeps jq in a list (exempt from set -e) so a non-zero exit captures rc instead
+# of aborting.
+jq_lacks() { local rc=0; jq -e "$@" >/dev/null 2>&1 || rc=$?; case "$rc" in 0) return 1 ;; 1|4) return 0 ;; *) return "$rc" ;; esac; }
 
 check_ruleset() { # name  expected-merge-method  expect-linear(true/false)
   local name="$1" method="$2" linear="$3" id rs


### PR DESCRIPTION
Consolidation of two fixes surfaced during the Utilities review that also apply here:

- **jq_lacks exit-4 bug:** `jq -e` exits 4 (not 1) when a filter yields no output, so the "main does not require linear history" assert (jq_lacks on a correctly-absent rule -> exit 4) failed on a correct ruleset. Treat exit 1 and 4 as "lacks"; propagate real jq errors (2/3/5). Verified under `set -euo pipefail`.
- **App-install README wording:** `check_app` only *notes* (best-effort) whether a GitHub App is installed; the README said the script "asserts" it. Separate the assert (secret names) from the note.