### PR TITLE
Match the whole LanguageData tree in the editorconfig byte-preserve rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -58,7 +58,7 @@ end_of_line = lf
 end_of_line = crlf
 
 # Downloaded language data - preserve the source bytes exactly; enforce no editor normalization
-[LanguageData/*]
+[LanguageData/**]
 charset = unset
 end_of_line = unset
 insert_final_newline = false


### PR DESCRIPTION
The `[LanguageData/*]` section only matched files directly under `LanguageData/`, leaving the `iso6392/`, `iso6393/`, `rfc5646/`, and `unm49/` subtrees without the no-normalization override. Use the recursive `[LanguageData/**]` glob so the override covers every downloaded data file, matching the `* -text` gitattributes contract.

Surfaced by the develop->main promotion review (#243).