### PR TITLE
Upload test coverage to Codecov

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -37,6 +37,8 @@ jobs:
   validate:
     name: Validate job
     uses: ./.github/workflows/validate-task.yml
+    # Thread CODECOV_TOKEN through so the unit-test job can upload coverage.
+    secrets: inherit
 
   # Build, version, validate, push, and release the triggering branch. Grants the write scopes
   # build-release-task needs (it declares none, so the read-only smoke caller is not forced to over-grant).

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -26,6 +26,8 @@ jobs:
     name: Validate job
     if: ${{ !github.event.deleted }}
     uses: ./.github/workflows/validate-task.yml
+    # Thread CODECOV_TOKEN through so the unit-test job can upload coverage.
+    secrets: inherit
 
   # Build and pack the library in its branch configuration to prove it ships, publishing nothing. Runs on
   # every push, so a change to build-release-task is exercised head-resolved in the PR that makes it.

--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -24,8 +24,18 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Builds with TreatWarningsAsErrors, so analyzer and code-style warnings fail here.
+      # --collect drives coverlet.collector to emit Cobertura XML into ./coverage/<guid>/.
       - name: Run unit tests step
-        run: dotnet test
+        run: dotnet test --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      # Report-only: fail_ci_if_error is false so a Codecov hiccup or an absent token never fails the gate.
+      - name: Upload coverage to Codecov step
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          directory: ./coverage
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # The same checks the editor runs interactively, enforced in CI from the same config files: CSharpier
   # formatting, dotnet format style (EditorConfig), markdownlint, cspell on the user-facing docs, and

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />

--- a/LanguageTagsTests/LanguageTagsTests.csproj
+++ b/LanguageTagsTests/LanguageTagsTests.csproj
@@ -12,6 +12,10 @@
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
     <PackageReference Include="xunit.v3" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LanguageTags\LanguageTags.csproj" />


### PR DESCRIPTION
Collect Cobertura coverage during unit tests and upload it best-effort to Codecov, mirroring the proven PlexCleaner pattern.

## Changes

- **validate-task.yml**: the unit-test job now runs `dotnet test --collect:"XPlat Code Coverage" --results-directory ./coverage`, followed by a `codecov/codecov-action@v7.0.0` upload step. The upload is report-only (`fail_ci_if_error: false`), so a Codecov hiccup or an absent token never fails the validation gate.
- **coverlet.collector**: added the `PackageReference` to `LanguageTagsTests.csproj` (it was missing) plus the `PackageVersion` (10.0.1) in `Directory.Packages.props`, matching the PlexCleaner form.
- **secrets threading**: both callers of `validate-task.yml` (`test-pull-request.yml` and `publish-release.yml`) now pass `secrets: inherit` so `CODECOV_TOKEN` reaches the unit-test job.

## Maintainer action required

`CODECOV_TOKEN` must be set as an Actions secret in the repo for uploads to authenticate. Until then the upload is a harmless no-op (report-only, non-failing).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>