### PR TITLE
Fix TOCTOU race in LogOptions.CreateLogger (#252)

### DIFF
--- a/LanguageTags/LogOptions.cs
+++ b/LanguageTags/LogOptions.cs
@@ -18,7 +18,7 @@ namespace ptr727.LanguageTags;
 /// </list>
 /// <para>
 /// Note that loggers are created and cached at the time of use by each class instance. Changes to <see cref="LoggerFactory"/>
-/// after a logger has been created will not affect existing cached loggers—only new logger requests will use the updated configuration.
+/// after a logger has been created will not affect existing cached loggers. Only new logger requests will use the updated configuration.
 /// </para>
 /// </remarks>
 public static class LogOptions
@@ -75,9 +75,10 @@ public static class LogOptions
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(categoryName);
 
-        // LoggerFactory -> NullLogger
-        return !ReferenceEquals(LoggerFactory, NullLoggerFactory.Instance)
-            ? LoggerFactory.CreateLogger(categoryName)
+        // Read once so a concurrent swap cannot split the check and the create across two instances.
+        ILoggerFactory factory = LoggerFactory;
+        return !ReferenceEquals(factory, NullLoggerFactory.Instance)
+            ? factory.CreateLogger(categoryName)
             : NullLogger.Instance;
     }
 }


### PR DESCRIPTION
Fixes #252.

## Problem
`LogOptions.CreateLogger(string)` read the `LoggerFactory` property twice — once for the `ReferenceEquals` guard and once for the actual `CreateLogger` call. Since the backing field is swapped with `Interlocked.Exchange`, a concurrent `SetFactory` could make the guard and the create observe different factory instances, defeating the thread-safe intent of the `Volatile`/`Interlocked` design.

## Fix
Read the factory once into a local and use it for both the check and the create. Also splits the `<remarks>` em-dash into two ASCII sentences, matching the sibling `ptr727.Utilities` fix (ptr727/Utilities#381).

## Verification
`dotnet test` — build clean, 296/296 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)