### PR TITLE
Promote develop to main: LogOptions CreateLogger TOCTOU fix

### DIFF
--- a/LanguageTags/LogOptions.cs
+++ b/LanguageTags/LogOptions.cs
@@ -18,7 +18,7 @@ namespace ptr727.LanguageTags;
 /// </list>
 /// <para>
 /// Note that loggers are created and cached at the time of use by each class instance. Changes to <see cref="LoggerFactory"/>
-/// after a logger has been created will not affect existing cached loggers—only new logger requests will use the updated configuration.
+/// after a logger has been created will not affect existing cached loggers. Only new logger requests will use the updated configuration.
 /// </para>
 /// </remarks>
 public static class LogOptions
@@ -75,9 +75,10 @@ public static class LogOptions
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(categoryName);
 
-        // LoggerFactory -> NullLogger
-        return !ReferenceEquals(LoggerFactory, NullLoggerFactory.Instance)
-            ? LoggerFactory.CreateLogger(categoryName)
+        // Read once so a concurrent swap cannot split the check and the create across two instances.
+        ILoggerFactory factory = LoggerFactory;
+        return !ReferenceEquals(factory, NullLoggerFactory.Instance)
+            ? factory.CreateLogger(categoryName)
             : NullLogger.Instance;
     }
 }


### PR DESCRIPTION
Promotes the `develop` prerelease to `main` for a stable release.

## Included
- Fix TOCTOU race in `LogOptions.CreateLogger` (#252, PR #253): read `LoggerFactory` once into a local so a concurrent swap cannot split the guard and the create; em-dash remark split into two ASCII sentences.

## Verification
`dotnet test` on the change — 296/296 pass. Copilot review on #253 passed with no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)