### PR TITLE
lint: EditorConfig rename + process-type VS Code Lint tasks

### DIFF
--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -81,5 +81,5 @@ jobs:
       - name: Lint workflows step
         uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
 
-      - name: Check line endings step
+      - name: Check EditorConfig step
         run: docker run --rm -v "$PWD":/check --workdir /check mstruebing/editorconfig-checker:latest

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -146,9 +146,10 @@
         // Lint group - the local full doc-lint surface (Docker at :latest), matching the CI lint set.
         // Run on demand. The pre-commit hook does language formatting only. Every repo carries these.
         {
-            "label": "Lint: Line Endings",
-            "type": "shell",
-            "command": "docker run --rm -v \"${workspaceFolder}:/check\" -w /check mstruebing/editorconfig-checker:latest",
+            "label": "Lint: EditorConfig",
+            "type": "process",
+            "command": "docker",
+            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/check", "-w", "/check", "mstruebing/editorconfig-checker:latest" ],
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,
@@ -157,8 +158,9 @@
         },
         {
             "label": "Lint: Workflows",
-            "type": "shell",
-            "command": "docker run --rm -v \"${workspaceFolder}:/repo\" -w /repo rhysd/actionlint:latest -color",
+            "type": "process",
+            "command": "docker",
+            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/repo", "-w", "/repo", "rhysd/actionlint:latest", "-color" ],
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,
@@ -167,8 +169,9 @@
         },
         {
             "label": "Lint: Markdown",
-            "type": "shell",
-            "command": "docker run --rm -v \"${workspaceFolder}:/workdir\" -w /workdir davidanson/markdownlint-cli2:latest \"**/*.md\"",
+            "type": "process",
+            "command": "docker",
+            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/workdir", "-w", "/workdir", "davidanson/markdownlint-cli2:latest", "**/*.md" ],
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,
@@ -177,8 +180,9 @@
         },
         {
             "label": "Lint: Spelling",
-            "type": "shell",
-            "command": "docker run --rm -v \"${workspaceFolder}:/workdir\" -w /workdir ghcr.io/streetsidesoftware/cspell:latest --no-progress README.md HISTORY.md",
+            "type": "process",
+            "command": "docker",
+            "args": [ "run", "--rm", "-v", "${workspaceFolder}:/workdir", "-w", "/workdir", "ghcr.io/streetsidesoftware/cspell:latest", "--no-progress", "README.md", "HISTORY.md" ],
             "problemMatcher": [],
             "presentation": {
                 "showReuseMessage": false,
@@ -189,7 +193,7 @@
             "label": "Lint: All",
             "dependsOrder": "sequence",
             "dependsOn": [
-                "Lint: Line Endings",
+                "Lint: EditorConfig",
                 "Lint: Workflows",
                 "Lint: Markdown",
                 "Lint: Spelling"


### PR DESCRIPTION
Applies fleet conventions from ProjectTemplate #280: rename `Check line endings` -> `Check EditorConfig` (CI step + VS Code task), and the VS Code Lint tasks use `type: process` with an args array (from shell+command).